### PR TITLE
Fix wrong parsing position for verbosity parameter

### DIFF
--- a/src/main/java/org/joda/beans/gen/BeanCodeGen.java
+++ b/src/main/java/org/joda/beans/gen/BeanCodeGen.java
@@ -117,7 +117,7 @@ public class BeanCodeGen {
                 }
                 config = BeanGenConfig.parse(arg.substring(8));
             } else if (arg.startsWith("-verbose=")) {
-                verbosity = Integer.parseInt(arg.substring(3));
+                verbosity = Integer.parseInt(arg.substring(9));
             } else if (arg.startsWith("-v=")) {
                 System.out.println("Deprecated command line argument -v (use -verbose instead)");
                 verbosity = Integer.parseInt(arg.substring(3));


### PR DESCRIPTION
Probably a C&P bug. Found this while trying some things with the code generator.
