### PR TITLE
Add DeserializerProvider

### DIFF
--- a/src/main/java/org/joda/beans/ser/CompositeDeserializerProvider.java
+++ b/src/main/java/org/joda/beans/ser/CompositeDeserializerProvider.java
@@ -1,0 +1,35 @@
+package org.joda.beans.ser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link DeserializerProvider} which combines multiple providers.
+ * <p>
+ * The providers are queried in order and the first non-null deserializer is returned.
+ */
+public final class CompositeDeserializerProvider implements DeserializerProvider {
+
+    private final List<DeserializerProvider> deserializers;
+
+    /**
+     * Creates an instance
+     *
+     * @param deserializers  the deserializers
+     */
+    public CompositeDeserializerProvider(List<DeserializerProvider> deserializers) {
+        this.deserializers = new ArrayList<DeserializerProvider>(deserializers);
+    }
+
+    @Override
+    public SerDeserializer findDeserializer(Class<?> type) {
+        for (DeserializerProvider provider : deserializers) {
+            SerDeserializer deserializer = provider.findDeserializer(type);
+
+            if (deserializer != null) {
+                return deserializer;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/joda/beans/ser/CompositeDeserializerProvider.java
+++ b/src/main/java/org/joda/beans/ser/CompositeDeserializerProvider.java
@@ -10,20 +10,20 @@ import java.util.List;
  */
 public final class CompositeDeserializerProvider implements DeserializerProvider {
 
-    private final List<DeserializerProvider> deserializers;
+    private final List<DeserializerProvider> providers;
 
     /**
      * Creates an instance
      *
-     * @param deserializers  the deserializers
+     * @param providers  the deserializers
      */
-    public CompositeDeserializerProvider(List<DeserializerProvider> deserializers) {
-        this.deserializers = new ArrayList<DeserializerProvider>(deserializers);
+    public CompositeDeserializerProvider(List<DeserializerProvider> providers) {
+        this.providers = new ArrayList<DeserializerProvider>(providers);
     }
 
     @Override
     public SerDeserializer findDeserializer(Class<?> type) {
-        for (DeserializerProvider provider : deserializers) {
+        for (DeserializerProvider provider : providers) {
             SerDeserializer deserializer = provider.findDeserializer(type);
 
             if (deserializer != null) {

--- a/src/main/java/org/joda/beans/ser/DeserializerProvider.java
+++ b/src/main/java/org/joda/beans/ser/DeserializerProvider.java
@@ -1,0 +1,19 @@
+package org.joda.beans.ser;
+
+/**
+ * A provider of {@link SerDeserializer} instances for serializing and deserializing beans.
+ * <p>
+ * Implementations of this interface can introspect the bean type when choosing a deserializer.
+ * This allows deserializers to be provided that can handle multiple bean types, for example all beans
+ * in a particular package, any bean with a particular supertype or with a particular annotation.
+ */
+public interface DeserializerProvider {
+
+    /**
+     * Returns a deserializer for the type or null if there is no deserializer available.
+     *
+     * @param type  the type for which a deserializer is required
+     * @return a deserializer for the type or null if there is no deserializer available
+     */
+    SerDeserializer findDeserializer(Class<?> type);
+}

--- a/src/main/java/org/joda/beans/ser/EmptyDeserializerProvider.java
+++ b/src/main/java/org/joda/beans/ser/EmptyDeserializerProvider.java
@@ -1,0 +1,26 @@
+package org.joda.beans.ser;
+
+/**
+ * A deserializer provider which never returns a deserializer.
+ */
+public class EmptyDeserializerProvider implements DeserializerProvider {
+
+    /**
+     * The single shared instance of this class.
+     */
+    public static final DeserializerProvider INSTANCE = new EmptyDeserializerProvider();
+
+    private EmptyDeserializerProvider() {
+    }
+
+    /**
+     * Returns null.
+     *
+     * @param type  not used
+     * @return null
+     */
+    @Override
+    public SerDeserializer findDeserializer(Class<?> type) {
+        return null;
+    }
+}

--- a/src/main/java/org/joda/beans/ser/SerDeserializers.java
+++ b/src/main/java/org/joda/beans/ser/SerDeserializers.java
@@ -41,12 +41,27 @@ public final class SerDeserializers {
     /**
      * The deserializers.
      */
-    private ConcurrentMap<Class<?>, SerDeserializer> deserializers = new ConcurrentHashMap<Class<?>, SerDeserializer>();
+    private final ConcurrentMap<Class<?>, SerDeserializer> deserializers = new ConcurrentHashMap<Class<?>, SerDeserializer>();
+
+    /**
+     * Provider of deserializers.
+     */
+    private final DeserializerProvider deserializerProvider;
+
+    /**
+     * Creates an instance.
+     *
+     * @param deserializerProvider  provides deserializers for beans
+     */
+    public SerDeserializers(DeserializerProvider deserializerProvider) {
+        this.deserializerProvider = deserializerProvider;
+    }
 
     /**
      * Creates an instance.
      */
     public SerDeserializers() {
+       this(EmptyDeserializerProvider.INSTANCE);
     }
 
     //-----------------------------------------------------------------------
@@ -82,6 +97,9 @@ public final class SerDeserializers {
      */
     public SerDeserializer findDeserializer(Class<?> type) {
         SerDeserializer deser = deserializers.get(type);
+        if (deser == null) {
+            deser = deserializerProvider.findDeserializer(type);
+        }
         if (deser == null) {
             deser = DefaultDeserializer.INSTANCE;
         }


### PR DESCRIPTION
Adds an interface `DeserializerProvider` which can provide a `SerDeserializer` instance for a type. 

Currently it is necessary to register a custom deserializer with `SerDeserializers` for each bean type that needs to use it.

Using a provider allows custom deserializers to be provided which can introspect the bean type when choosing the deserializer. This allows deserializers to be provider which handle multiple types, for example all beans in a package, or all beans with a particular supertype or annotation.
