### PR TITLE
Fix parsing of config commandline argument and jdk6 config

### DIFF
--- a/src/main/java/org/joda/beans/gen/BeanCodeGen.java
+++ b/src/main/java/org/joda/beans/gen/BeanCodeGen.java
@@ -111,7 +111,7 @@ public class BeanCodeGen {
                 prefix = arg.substring(8);
             } else if (arg.equals("-R")) {
                 recurse = true;
-            } else if (arg.equals("-config=")) {
+            } else if (arg.startsWith("-config=")) {
                 if (config != null) {
                     throw new IllegalArgumentException("Argument 'config' must not be specified twice: " + Arrays.toString(args));
                 }

--- a/src/main/resources/org/joda/beans/gen/jdk6.ini
+++ b/src/main/resources/org/joda/beans/gen/jdk6.ini
@@ -79,7 +79,7 @@ SortedMultiset =
 ImmutableCollection =
 ImmutableList =
 ImmutableSet =
-ImmutableSortedSet
+ImmutableSortedSet =
 ImmutableMap =
 ImmutableSortedMap =
 ImmutableBiMap =


### PR DESCRIPTION
Parsing step wrongly checked full argument instead of just parameter name
