### PR TITLE
#171: codegen: propertyChangeSupport

### DIFF
--- a/src/main/java/org/joda/beans/gen/BeanGen.java
+++ b/src/main/java/org/joda/beans/gen/BeanGen.java
@@ -523,7 +523,7 @@ class BeanGen {
             insertRegion.add("\t/**");
             insertRegion.add("\t * The property change support field.");
             insertRegion.add("\t */");
-            insertRegion.add("\tprivate PropertyChangeSupport " + config.getPrefix() + "propertyChangeSupport = new PropertyChangeSupport(this);");
+            insertRegion.add("\tprivate final transient PropertyChangeSupport " + config.getPrefix() + "propertyChangeSupport = new PropertyChangeSupport(this);");
             insertRegion.add("");
         }
     }


### PR DESCRIPTION
propertyChangeSupport now gets generated as private final transient.

Tests run OK.
I tested the change on my own (private) consumer project. Everything works fine. No need to update the maven plugin that generates the code.

As discussed, the project probably wants to keep issue #171 open, as this pull requests only satisfies one of the two proposed changes.
