### PR TITLE
JodaBeanXmlWriter write to appendable

### DIFF
--- a/src/main/java/org/joda/beans/ser/xml/JodaBeanXmlWriter.java
+++ b/src/main/java/org/joda/beans/ser/xml/JodaBeanXmlWriter.java
@@ -179,6 +179,8 @@ public class JodaBeanXmlWriter {
      *
      * @param bean  the bean to output, not null
      * @param rootType  true to output the root type
+     * @param builder  the output appendable, not null
+     * @throws IOException if an error occurs
      */
     public void write(final Bean bean, final boolean rootType, final Appendable builder) throws IOException {
         if (bean == null) {

--- a/src/test/java/org/joda/beans/ser/xml/TestSerializeXml.java
+++ b/src/test/java/org/joda/beans/ser/xml/TestSerializeXml.java
@@ -17,6 +17,7 @@ package org.joda.beans.ser.xml;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.CharArrayWriter;
 import java.io.IOException;
 
 import org.joda.beans.Bean;
@@ -56,6 +57,17 @@ public class TestSerializeXml {
         
         Address bean = (Address) JodaBeanSer.PRETTY.xmlReader().read(xml);
 //        System.out.println(bean);
+        BeanAssert.assertBeanEquals(bean, address);
+    }
+
+    @Test
+    public void test_writeToAppendable() throws IOException {
+        Address address = SerTestHelper.testAddress();
+        CharArrayWriter output = new CharArrayWriter();
+        JodaBeanSer.PRETTY.xmlWriter().write(address, output);
+        String xml = output.toString();
+
+        Address bean = (Address) JodaBeanSer.PRETTY.xmlReader().read(xml);
         BeanAssert.assertBeanEquals(bean, address);
     }
 


### PR DESCRIPTION
Kept all of the variable names the same to reduce the diff size.
Only odd thing is that JodaBeanJsonWriter and JodaBeanBinWriter both only overload a `.write()` method with versions that take `Appendable` and `OutputStream` respectively, whereas here we have a `.writeToBuilder()`.
Also not sure whether it's correct to leave the current default StringBuilder in place but I guess that's backwards compatibility.