### PR TITLE
Fix for referencing bean format using incorrect class name with JodaConvert interfaces

### DIFF
--- a/src/main/java/org/joda/beans/ser/bin/BeanReferences.java
+++ b/src/main/java/org/joda/beans/ser/bin/BeanReferences.java
@@ -33,7 +33,6 @@ import org.joda.beans.MetaBean;
 import org.joda.beans.MetaProperty;
 import org.joda.beans.ser.JodaBeanSer;
 import org.joda.beans.ser.SerCategory;
-import org.joda.beans.ser.SerDeserializer;
 import org.joda.beans.ser.SerIterator;
 import org.joda.beans.ser.SerOptional;
 
@@ -161,9 +160,6 @@ final class BeanReferences {
                         } else {
                             findReferencesBean(value, type, objects, null);
                         }
-                    } else {
-                        // In case it's a null value or optional field
-                        addClassInfo(type, type);
                     }
                 }
             }
@@ -236,35 +232,9 @@ final class BeanReferences {
 
             addClassInfoAndIncrementCount(bean.getClass(), classInfo);
             
-        } else if (value instanceof Class<?>) {
-            Class<?> type = (Class<?>) value;
-            if (type.equals(declaredClass) || settings.getConverter().isConvertible(type)) {
-                return;
-            }
-            if (Bean.class.isAssignableFrom(type) && !ImmutableBean.class.isAssignableFrom(type)) {
-                throw new IllegalArgumentException(
-                        "Can only serialize immutable beans in referencing binary format: " + type.getName());
-            }
-            if (ImmutableBean.class.isAssignableFrom(type)) {
-                if (classes.containsKey(type)) {
-                    classSerializationCount.compute(type, BeanReferences::incrementOrOne);
-                    return;
-                }
-                ClassInfo classInfo;
-                if (settings.getConverter().isConvertible(type)) {
-                    // Don't need metaproperty info if it's a convertible type
-                    classInfo = new ClassInfo(type, new MetaProperty<?>[0]);
-                } else {
-                    SerDeserializer deser = settings.getDeserializers().findDeserializer(type);
-                    MetaBean metaBean = deser.findMetaBean(type);
-                    classInfo = classInfoFromMetaBean(metaBean, type);
-                }
-                addClassInfoAndIncrementCount(type, classInfo);
-            }
-            
         } else if (declaredClass == Object.class && !value.getClass().equals(String.class)) {
             Class<?> effectiveType = settings.getConverter().findTypedConverter(value.getClass()).getEffectiveType();
-            ClassInfo classInfo = new ClassInfo(value.getClass(), new MetaProperty<?>[0]);
+            ClassInfo classInfo = new ClassInfo(effectiveType, new MetaProperty<?>[0]);
             addClassInfoAndIncrementCount(effectiveType, classInfo);
             
         } else if (!settings.getConverter().isConvertible(declaredClass)) {

--- a/src/main/java/org/joda/beans/ser/bin/BeanReferences.java
+++ b/src/main/java/org/joda/beans/ser/bin/BeanReferences.java
@@ -78,7 +78,7 @@ final class BeanReferences {
     // finds classes and references within the bean
     private void findReferences(ImmutableBean root) {
         // handle root bean
-        classes.put(root.getClass(), classInfoFromMetaBean(root.metaBean(), root.getClass()));
+        classes.put(root.getClass(), classInfoFromMetaBean(root.metaBean()));
         classSerializationCount.put(root.getClass(), 1);
 
         // recursively check object graph
@@ -228,7 +228,7 @@ final class BeanReferences {
             // Don't need metaproperty info if it's a convertible type
             ClassInfo classInfo = isConvertible ?
                     new ClassInfo(value.getClass(), new MetaProperty<?>[0]) :
-                    classInfoFromMetaBean(bean.metaBean(), bean.getClass());
+                    classInfoFromMetaBean(bean.metaBean());
 
             addClassInfoAndIncrementCount(bean.getClass(), classInfo);
             
@@ -250,13 +250,13 @@ final class BeanReferences {
     }
 
     // converts a meta-bean to a ClassInfo
-    private ClassInfo classInfoFromMetaBean(MetaBean metaBean, Class<?> aClass) {
+    private ClassInfo classInfoFromMetaBean(MetaBean metaBean) {
         MetaProperty<?>[] metaProperties = StreamSupport.stream(metaBean.metaPropertyIterable().spliterator(), false)
             .filter(metaProp -> settings.isSerialized(metaProp))
             .toArray(MetaProperty<?>[]::new);
 
         // Positions get recreated when all classes have been recorded
-        return new ClassInfo(aClass, metaProperties);
+        return new ClassInfo(metaBean.beanType(), metaProperties);
     }
 
     // Used in Map#compute so we can initialise all the values to one and then increment

--- a/src/test/java/org/joda/beans/sample/JodaConvertInterface.java
+++ b/src/test/java/org/joda/beans/sample/JodaConvertInterface.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.sample;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+/**
+ * Mock JodaConvert interface, used for testing.
+ */
+public interface JodaConvertInterface {
+
+    @FromString
+    public static JodaConvertInterface of(String uniqueName) {
+        return uniqueName.equalsIgnoreCase(First.instance.toString()) ?
+            First.instance :
+            Second.instance;
+    }
+
+    @ToString
+    public abstract String toString();
+
+    final class First implements JodaConvertInterface {
+
+        static final First instance = new First();
+
+        @Override
+        public String toString() {
+            return "First";
+        }
+    }
+
+    final class Second implements JodaConvertInterface {
+
+        static final Second instance = new Second();
+
+        @Override
+        public String toString() {
+            return "Second";
+        }
+    }
+}

--- a/src/test/java/org/joda/beans/sample/JodaConvertInterface.java
+++ b/src/test/java/org/joda/beans/sample/JodaConvertInterface.java
@@ -25,9 +25,9 @@ public interface JodaConvertInterface {
 
     @FromString
     public static JodaConvertInterface of(String uniqueName) {
-        return uniqueName.equalsIgnoreCase(First.instance.toString()) ?
-            First.instance :
-            Second.instance;
+        return uniqueName.equalsIgnoreCase(First.INSTANCE.toString()) ?
+            First.INSTANCE :
+            Second.INSTANCE;
     }
 
     @ToString
@@ -35,7 +35,7 @@ public interface JodaConvertInterface {
 
     final class First implements JodaConvertInterface {
 
-        static final First instance = new First();
+        static final First INSTANCE = new First();
 
         @Override
         public String toString() {
@@ -45,7 +45,7 @@ public interface JodaConvertInterface {
 
     final class Second implements JodaConvertInterface {
 
-        static final Second instance = new Second();
+        static final Second INSTANCE = new Second();
 
         @Override
         public String toString() {

--- a/src/test/java/org/joda/beans/ser/SerTestHelper.java
+++ b/src/test/java/org/joda/beans/ser/SerTestHelper.java
@@ -38,6 +38,7 @@ import org.joda.beans.sample.ImmKey;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.ImmPerson;
 import org.joda.beans.sample.ImmTreeNode;
+import org.joda.beans.sample.JodaConvertInterface;
 import org.joda.beans.sample.Person;
 import org.joda.beans.sample.PrimitiveBean;
 import org.joda.beans.sample.RiskLevel;
@@ -213,6 +214,14 @@ public class SerTestHelper {
             .sortedMapInterface(sortedMap)
             .biMap(bimap)
             .biMapInterface(bimap)
+            .build();
+    }
+    
+    public static ImmGenericCollections<JodaConvertInterface> testGenericInterfaces() {
+        return ImmGenericCollections.<JodaConvertInterface>builder()
+            .map(ImmutableMap.of(
+                "First", JodaConvertInterface.of("First"),
+                "Second", JodaConvertInterface.of("Second")))
             .build();
     }
 

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
@@ -42,8 +42,6 @@ import org.joda.beans.ser.SerTestHelper;
 import org.joda.beans.test.BeanAssert;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Test property roundtrip using referencing binary.
  */
@@ -74,11 +72,7 @@ public class TestSerializeReferencingBin {
 
     @Test
     public void test_writeJodaConvertInterface() {
-        ImmGenericCollections<JodaConvertInterface> array = ImmGenericCollections.<JodaConvertInterface>builder()
-            .map(ImmutableMap.of(
-                "First", JodaConvertInterface.of("First"),
-                "Second", JodaConvertInterface.of("Second")))
-            .build();
+        ImmGenericCollections<JodaConvertInterface> array = SerTestHelper.testGenericInterfaces();
 
         byte[] bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(array);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
@@ -36,10 +36,13 @@ import org.joda.beans.sample.ImmJodaConvertBean;
 import org.joda.beans.sample.ImmJodaConvertWrapper;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.ImmTreeNode;
+import org.joda.beans.sample.JodaConvertInterface;
 import org.joda.beans.ser.JodaBeanSer;
 import org.joda.beans.ser.SerTestHelper;
 import org.joda.beans.test.BeanAssert;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Test property roundtrip using referencing binary.
@@ -67,6 +70,23 @@ public class TestSerializeReferencingBin {
         ImmGuava<String> bean = (ImmGuava<String>) JodaBeanSer.COMPACT.binReader().read(bytes);
 //        System.out.println(bean);
         BeanAssert.assertBeanEquals(bean, optional);
+    }
+
+    @Test
+    public void test_writeJodaConvertInterface() {
+        ImmGenericCollections<JodaConvertInterface> array = ImmGenericCollections.<JodaConvertInterface>builder()
+            .map(ImmutableMap.of(
+                "First", JodaConvertInterface.of("First"),
+                "Second", JodaConvertInterface.of("Second")))
+            .build();
+
+        byte[] bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(array);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+
+        @SuppressWarnings("unchecked")
+        ImmGenericCollections<JodaConvertInterface> bean = (ImmGenericCollections<JodaConvertInterface>) JodaBeanSer.COMPACT.binReader().read(bytes);
+//        System.out.println(bean);
+        BeanAssert.assertBeanEquals(bean, array);
     }
 
     @Test

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializeStandardBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializeStandardBin.java
@@ -29,9 +29,11 @@ import org.joda.beans.sample.Address;
 import org.joda.beans.sample.Company;
 import org.joda.beans.sample.ImmAddress;
 import org.joda.beans.sample.ImmDoubleFloat;
+import org.joda.beans.sample.ImmGenericCollections;
 import org.joda.beans.sample.ImmGuava;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.JodaConvertBean;
+import org.joda.beans.sample.JodaConvertInterface;
 import org.joda.beans.sample.JodaConvertWrapper;
 import org.joda.beans.sample.Person;
 import org.joda.beans.ser.JodaBeanSer;
@@ -88,6 +90,19 @@ public class TestSerializeStandardBin {
         ImmGuava<String> bean = (ImmGuava<String>) JodaBeanSer.PRETTY.binReader().read(bytes);
 //        System.out.println(bean);
         BeanAssert.assertBeanEquals(bean, optional);
+    }
+
+    @Test
+    public void test_writeJodaConvertInterface() {
+        ImmGenericCollections<JodaConvertInterface> array = SerTestHelper.testGenericInterfaces();
+        
+        byte[] bytes = JodaBeanSer.COMPACT.binWriter().write(array);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        
+        @SuppressWarnings("unchecked")
+        ImmGenericCollections<JodaConvertInterface> bean = (ImmGenericCollections<JodaConvertInterface>) JodaBeanSer.COMPACT.binReader().read(bytes);
+//        System.out.println(bean);
+        BeanAssert.assertBeanEquals(bean, array);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
+++ b/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
@@ -29,12 +29,14 @@ import org.joda.beans.sample.Address;
 import org.joda.beans.sample.ImmAddress;
 import org.joda.beans.sample.ImmDoubleFloat;
 import org.joda.beans.sample.ImmEmpty;
+import org.joda.beans.sample.ImmGenericCollections;
 import org.joda.beans.sample.ImmGuava;
 import org.joda.beans.sample.ImmKey;
 import org.joda.beans.sample.ImmMappedKey;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.ImmPerson;
 import org.joda.beans.sample.JodaConvertBean;
+import org.joda.beans.sample.JodaConvertInterface;
 import org.joda.beans.sample.JodaConvertWrapper;
 import org.joda.beans.sample.Person;
 import org.joda.beans.sample.PrimitiveBean;
@@ -105,6 +107,19 @@ public class TestSerializeJson {
         ImmGuava<String> bean = (ImmGuava<String>) JodaBeanSer.PRETTY.jsonReader().read(json);
 //        System.out.println(bean);
         BeanAssert.assertBeanEquals(bean, optional);
+    }
+
+    @Test
+    public void test_writeJodaConvertInterface() {
+        ImmGenericCollections<JodaConvertInterface> array = SerTestHelper.testGenericInterfaces();
+        
+        String json = JodaBeanSer.COMPACT.jsonWriter().write(array);
+//        System.out.println(json);
+        
+        @SuppressWarnings("unchecked")
+        ImmGenericCollections<JodaConvertInterface> bean = (ImmGenericCollections<JodaConvertInterface>) JodaBeanSer.COMPACT.jsonReader().read(json);
+//        System.out.println(bean);
+        BeanAssert.assertBeanEquals(bean, array);
     }
 
     private void assertEqualsSerialization(String json, String expectedResource) throws IOException {

--- a/src/test/java/org/joda/beans/ser/xml/TestSerializeXml.java
+++ b/src/test/java/org/joda/beans/ser/xml/TestSerializeXml.java
@@ -26,12 +26,14 @@ import org.joda.beans.sample.Address;
 import org.joda.beans.sample.ImmAddress;
 import org.joda.beans.sample.ImmDoubleFloat;
 import org.joda.beans.sample.ImmEmpty;
+import org.joda.beans.sample.ImmGenericCollections;
 import org.joda.beans.sample.ImmGuava;
 import org.joda.beans.sample.ImmKey;
 import org.joda.beans.sample.ImmMappedKey;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.ImmPerson;
 import org.joda.beans.sample.JodaConvertBean;
+import org.joda.beans.sample.JodaConvertInterface;
 import org.joda.beans.sample.JodaConvertWrapper;
 import org.joda.beans.sample.Person;
 import org.joda.beans.sample.SimpleName;
@@ -105,6 +107,19 @@ public class TestSerializeXml {
         ImmGuava<String> bean = (ImmGuava<String>) JodaBeanSer.PRETTY.xmlReader().read(xml);
 //        System.out.println(bean);
         BeanAssert.assertBeanEquals(bean, optional);
+    }
+    
+    @Test
+    public void test_writeJodaConvertInterface() {
+        ImmGenericCollections<JodaConvertInterface> array = SerTestHelper.testGenericInterfaces();
+        
+        String xml = JodaBeanSer.COMPACT.xmlWriter().write(array);
+//        System.out.println(xml);
+        
+        @SuppressWarnings("unchecked")
+        ImmGenericCollections<JodaConvertInterface> bean = (ImmGenericCollections<JodaConvertInterface>) JodaBeanSer.COMPACT.xmlReader().read(xml);
+//        System.out.println(bean);
+        BeanAssert.assertBeanEquals(bean, array);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Currently if one serializes an immutable bean which holds under an Object reference something implementing a JodaConvert interface with multiple implementations and the type is required to be serialized then the referencing converter chooses to serialize the first concrete implementation class name it encounters, rather than that of the interface itself.

Added a test case for it and deleted some useless code (we don't care about serializing class names for null values; also serializing classes as values is easy, just write the class name!)