### PR TITLE
Buffering bean builder cannot set null value

### DIFF
--- a/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
+++ b/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
@@ -121,12 +121,10 @@ public class BufferingBeanBuilder<T extends Bean>
 
     @Override
     public BeanBuilder<T> set(MetaProperty<?> metaProperty, Object value) {
-        if (value == null) {
-            // ConcurrentHashMap does not allow null values
-            // As setting to null is functionally equivalent to not setting can return
-            return this;
+        if (value != null) {
+            // ConcurrentHashMap does not allow null values and setting to null is equivalent to not setting
+            getBuffer().put(metaProperty, value);
         }
-        getBuffer().put(metaProperty, value);
         return this;
     }
 

--- a/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
+++ b/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
@@ -121,6 +121,11 @@ public class BufferingBeanBuilder<T extends Bean>
 
     @Override
     public BeanBuilder<T> set(MetaProperty<?> metaProperty, Object value) {
+        if (value == null) {
+            // ConcurrentHashMap does not allow null values
+            // As setting to null is functionally equivalent to not setting can continue
+            return this;
+        }
         getBuffer().put(metaProperty, value);
         return this;
     }

--- a/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
+++ b/src/main/java/org/joda/beans/impl/BufferingBeanBuilder.java
@@ -123,7 +123,7 @@ public class BufferingBeanBuilder<T extends Bean>
     public BeanBuilder<T> set(MetaProperty<?> metaProperty, Object value) {
         if (value == null) {
             // ConcurrentHashMap does not allow null values
-            // As setting to null is functionally equivalent to not setting can continue
+            // As setting to null is functionally equivalent to not setting can return
             return this;
         }
         getBuffer().put(metaProperty, value);


### PR DESCRIPTION
BeanBuilder#set should be able to accept null values, however BufferingBeanBuilder tries to set the value on a ConcurrentHashMap which explicitly does not allow them.

(Exposed while testing JodaBeanReferencingBinFormat, since it's the only format to explicitly serialize null values and then try to set them on the bean builder)