### PR TITLE
Meta provider annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,9 +228,5 @@
     <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
     <revapi-maven-plugin.version>0.10.0</revapi-maven-plugin.version>
     <revapi-java.version>0.15.1</revapi-java.version>
-    <!--TODO temporary-->
-    <!--<maven.compiler.compilerVersion>9</maven.compiler.compilerVersion>
-    <maven.compiler.source>9</maven.compiler.source>
-    <maven.compiler.target>9</maven.compiler.target>-->
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -228,5 +228,9 @@
     <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
     <revapi-maven-plugin.version>0.10.0</revapi-maven-plugin.version>
     <revapi-java.version>0.15.1</revapi-java.version>
+    <!--TODO temporary-->
+    <!--<maven.compiler.compilerVersion>9</maven.compiler.compilerVersion>
+    <maven.compiler.source>9</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>-->
   </properties>
 </project>

--- a/src/main/java/org/joda/beans/MetaBeanProvider.java
+++ b/src/main/java/org/joda/beans/MetaBeanProvider.java
@@ -8,7 +8,7 @@ package org.joda.beans;
 /**
  *
  */
-interface MetaBeanProvider {
+public interface MetaBeanProvider {
 
     MetaBean findMetaBean(Class<?> cls);
 }

--- a/src/main/java/org/joda/beans/MetaBeanProvider.java
+++ b/src/main/java/org/joda/beans/MetaBeanProvider.java
@@ -6,9 +6,15 @@
 package org.joda.beans;
 
 /**
- *
+ * A provider of {@link MetaBean} instances for bean classes.
  */
 public interface MetaBeanProvider {
 
+    /**
+     * Returns the meta bean for the class or null if no meta bean can be found.
+     *
+     * @param cls the class for which the meta bean is required
+     * @return the meta bean for the class or null if no meta bean can be found
+     */
     MetaBean findMetaBean(Class<?> cls);
 }

--- a/src/main/java/org/joda/beans/MetaBeanProvider.java
+++ b/src/main/java/org/joda/beans/MetaBeanProvider.java
@@ -1,8 +1,3 @@
-/*
- * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
- *
- * Please see distribution for license.
- */
 package org.joda.beans;
 
 /**

--- a/src/main/java/org/joda/beans/MetaBeanProvider.java
+++ b/src/main/java/org/joda/beans/MetaBeanProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package org.joda.beans;
+
+/**
+ *
+ */
+interface MetaBeanProvider {
+
+    MetaBean findMetaBean(Class<?> cls);
+}

--- a/src/main/java/org/joda/beans/MetaBeanProvider.java
+++ b/src/main/java/org/joda/beans/MetaBeanProvider.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.joda.beans;
 
 /**

--- a/src/main/java/org/joda/beans/MetaBeans.java
+++ b/src/main/java/org/joda/beans/MetaBeans.java
@@ -135,7 +135,6 @@ final class MetaBeans {
         return findProviderAnnotation(superclass);
     }
 
-
     /**
      * Registers a meta-bean.
      * <p>

--- a/src/main/java/org/joda/beans/MetaBeans.java
+++ b/src/main/java/org/joda/beans/MetaBeans.java
@@ -15,11 +15,11 @@
  */
 package org.joda.beans;
 
-import org.joda.beans.impl.flexi.FlexiBean;
-import org.joda.beans.impl.map.MapBean;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.joda.beans.impl.flexi.FlexiBean;
+import org.joda.beans.impl.map.MapBean;
 
 /**
  * Utilities for registered meta-beans.
@@ -99,7 +99,7 @@ final class MetaBeans {
                 return meta;
             } catch (Exception e) {
                 throw new IllegalStateException("Unable to create instance of " + providerClass.getName() +
-                        " to provide meta bean for " + cls.getName());
+                        " to provide meta bean for " + cls.getName(), e);
             }
         }
         throw new IllegalArgumentException("Unable to find meta-bean: " + cls.getName());

--- a/src/main/java/org/joda/beans/MetaBeans.java
+++ b/src/main/java/org/joda/beans/MetaBeans.java
@@ -83,8 +83,8 @@ final class MetaBeans {
             throw new IllegalArgumentException("Unable to find meta-bean: " + cls.getName(), ex);
         }
         MetaBean meta = META_BEANS.get(cls);
-        if (meta == null) {
-            throw new IllegalArgumentException("Unable to find meta-bean: " + cls.getName());
+        if (meta != null) {
+            return meta;
         }
         MetaProvider providerAnnotation = findProviderAnnotation(cls);
         if (providerAnnotation != null) {
@@ -102,7 +102,7 @@ final class MetaBeans {
                         " to provide meta bean for " + cls.getName());
             }
         }
-        return meta;
+        throw new IllegalArgumentException("Unable to find meta-bean: " + cls.getName());
     }
 
     // returns the MetaProvider annotation from the class or null if none can be found.

--- a/src/main/java/org/joda/beans/MetaBeans.java
+++ b/src/main/java/org/joda/beans/MetaBeans.java
@@ -32,6 +32,11 @@ final class MetaBeans {
     private static final ConcurrentHashMap<Class<?>, MetaBean> META_BEANS = new ConcurrentHashMap<>();
 
     /**
+     * The cache of meta-bean providers.
+     */
+    private static final ConcurrentHashMap<Class<?>, MetaBeanProvider> META_BEAN_PROVIDERS = new ConcurrentHashMap<>();
+
+    /**
      * Restricted constructor.
      */
     private MetaBeans() {
@@ -90,7 +95,11 @@ final class MetaBeans {
         if (providerAnnotation != null) {
             Class<? extends MetaBeanProvider> providerClass = providerAnnotation.value();
             try {
-                MetaBeanProvider provider = providerClass.getDeclaredConstructor().newInstance();
+                MetaBeanProvider provider = META_BEAN_PROVIDERS.get(providerClass);
+                if (provider == null) {
+                    provider = providerClass.getDeclaredConstructor().newInstance();
+                    META_BEAN_PROVIDERS.put(providerClass, provider);
+                }
                 meta = provider.findMetaBean(cls);
                 if (meta == null) {
                     throw new IllegalArgumentException("Unable to find meta-bean: " + cls.getName());

--- a/src/main/java/org/joda/beans/MetaProvider.java
+++ b/src/main/java/org/joda/beans/MetaProvider.java
@@ -1,11 +1,10 @@
-/*
- * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
- *
- * Please see distribution for license.
- */
 package org.joda.beans;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Specifies the type of the {@link MetaBeanProvider} that can provide a {@link MetaBean}

--- a/src/main/java/org/joda/beans/MetaProvider.java
+++ b/src/main/java/org/joda/beans/MetaProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package org.joda.beans;
+
+import java.lang.annotation.*;
+
+/**
+ * Specifies the type of the {@link MetaBeanProvider} that can provide a {@link MetaBean}
+ * for the annotated type.
+ * <p>
+ * The provider class must have a no-args constructor.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface MetaProvider {
+
+    Class<? extends MetaBeanProvider> value();
+}

--- a/src/main/java/org/joda/beans/MetaProvider.java
+++ b/src/main/java/org/joda/beans/MetaProvider.java
@@ -1,10 +1,21 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.joda.beans;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Specifies the type of the {@link MetaBeanProvider} that can provide a {@link MetaBean}

--- a/src/test/java/org/joda/beans/TestMetaBeanProvider.java
+++ b/src/test/java/org/joda/beans/TestMetaBeanProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package org.joda.beans;
+
+public class TestMetaBeanProvider implements MetaBeanProvider {
+
+  @Override
+  public MetaBean findMetaBean(Class<?> cls) {
+    if (cls.equals(AnnotatedBean.class)) {
+      return new AnnotatedMetaBean();
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/test/java/org/joda/beans/TestMetaBeanProvider.java
+++ b/src/test/java/org/joda/beans/TestMetaBeanProvider.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.joda.beans;
 
 public class TestMetaBeanProvider implements MetaBeanProvider {

--- a/src/test/java/org/joda/beans/TestMetaBeanProvider.java
+++ b/src/test/java/org/joda/beans/TestMetaBeanProvider.java
@@ -1,8 +1,3 @@
-/*
- * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
- *
- * Please see distribution for license.
- */
 package org.joda.beans;
 
 public class TestMetaBeanProvider implements MetaBeanProvider {

--- a/src/test/java/org/joda/beans/TestMetaBeans.java
+++ b/src/test/java/org/joda/beans/TestMetaBeans.java
@@ -1,11 +1,26 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.joda.beans;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 public class TestMetaBeans {
 

--- a/src/test/java/org/joda/beans/TestMetaBeans.java
+++ b/src/test/java/org/joda/beans/TestMetaBeans.java
@@ -1,8 +1,3 @@
-/*
- * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
- *
- * Please see distribution for license.
- */
 package org.joda.beans;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/joda/beans/TestMetaBeans.java
+++ b/src/test/java/org/joda/beans/TestMetaBeans.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package org.joda.beans;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class TestMetaBeans {
+
+  @Test
+  public void test_metaBeanProviderAnnotation() {
+    MetaBean metaBean = MetaBeans.lookup(AnnotatedBean.class);
+    assertTrue(metaBean instanceof AnnotatedMetaBean);
+  }
+}
+
+// --------------------------------------------------------------------------------------------------
+
+@MetaProvider(TestMetaBeanProvider.class)
+class AnnotatedBean implements Bean {
+
+  @Override
+  public MetaBean metaBean() {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+}
+
+class AnnotatedMetaBean implements MetaBean {
+
+  @Override
+  public boolean isBuildable() {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+
+  @Override
+  public BeanBuilder<? extends Bean> builder() {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+
+  @Override
+  public Class<? extends Bean> beanType() {
+    return AnnotatedBean.class;
+  }
+
+  @Override
+  public Map<String, MetaProperty<?>> metaPropertyMap() {
+    throw new UnsupportedOperationException("This method is not needed for testing");
+  }
+}
+


### PR DESCRIPTION
Adds an annotation `MetaProvider` and an interface `MetaBeanProvider`. `MetaProvider` has a `value` that is a class implementing `MetaBeanProvider`.

`MetaProvider` is applied to bean classes to indicate what `MetaBeanProvider` should be used to find its `MetaBean`.

This provides an alternative to static registration for finding meta beans. This allows a class to implement `Bean` and interoperate with Joda Beans serialization just by implementing an interface containing default methods.