### PR TITLE
Use unchecked exceptions in JsonOutput

### DIFF
--- a/src/main/java/org/joda/beans/ser/json/JsonOutput.java
+++ b/src/main/java/org/joda/beans/ser/json/JsonOutput.java
@@ -16,6 +16,7 @@
 package org.joda.beans.ser.json;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.BitSet;
 
 /**
@@ -90,23 +91,31 @@ final class JsonOutput {
     /**
      * Writes a JSON null.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeNull() throws IOException {
-        output.append("null");
+    void writeNull() {
+        try {
+            output.append("null");
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
      * Writes a JSON boolean.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeBoolean(boolean value) throws IOException {
-        if (value) {
-            output.append("true");
-        } else {
-            output.append("false");
+    void writeBoolean(boolean value) {
+        try {
+            if (value) {
+                output.append("true");
+            } else {
+                output.append("false");
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
@@ -115,13 +124,17 @@ final class JsonOutput {
      * Writes a JSON int.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeInt(int value) throws IOException {
-        if ((value & 0xfffffff8) == 0) {
-            output.append((char) (value + 48));
-        } else {
-            output.append(Integer.toString(value));
+    void writeInt(int value) {
+        try {
+            if ((value & 0xfffffff8) == 0) {
+                output.append((char) (value + 48));
+            } else {
+                output.append(Integer.toString(value));
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
@@ -129,10 +142,14 @@ final class JsonOutput {
      * Writes a JSON long.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeLong(long value) throws IOException {
-        output.append(Long.toString(value));
+    void writeLong(long value) {
+        try {
+            output.append(Long.toString(value));
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
@@ -141,13 +158,17 @@ final class JsonOutput {
      * This outputs the values of NaN, and Infinity as strings.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeFloat(float value) throws IOException {
-        if (Float.isNaN(value) || Float.isInfinite(value)) {
-            output.append('"').append(Float.toString(value)).append('"');
-        } else {
-            output.append(Float.toString(value));
+    void writeFloat(float value) {
+        try {
+            if (Float.isNaN(value) || Float.isInfinite(value)) {
+                output.append('"').append(Float.toString(value)).append('"');
+            } else {
+                output.append(Float.toString(value));
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
@@ -157,13 +178,17 @@ final class JsonOutput {
      * This outputs the values of NaN, and Infinity as strings.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeDouble(double value) throws IOException {
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
-            output.append('"').append(Double.toString(value)).append('"');
-        } else {
-            output.append(Double.toString(value));
+    void writeDouble(double value) {
+        try {
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                output.append('"').append(Double.toString(value)).append('"');
+            } else {
+                output.append(Double.toString(value));
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
@@ -172,79 +197,99 @@ final class JsonOutput {
      * Writes a JSON string.
      * 
      * @param value  the value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeString(String value) throws IOException {
-        output.append('"');
-        for (var i = 0; i < value.length(); i++) {
-            var ch = value.charAt(i);
-            if (ch < 128) {
-                var replace = REPLACE[ch];
-                if (replace != null) {
-                    output.append(replace);
+    void writeString(String value) {
+        try {
+            output.append('"');
+            for (var i = 0; i < value.length(); i++) {
+                var ch = value.charAt(i);
+                if (ch < 128) {
+                    var replace = REPLACE[ch];
+                    if (replace != null) {
+                        output.append(replace);
+                    } else {
+                        output.append(ch);
+                    }
+                } else if (ch == '\u2028') {
+                    output.append("\\u2028");  // match other JSON writers
+                } else if (ch == '\u2029') {
+                    output.append("\\u2029");  // match other JSON writers
                 } else {
                     output.append(ch);
                 }
-            } else if (ch == '\u2028') {
-                output.append("\\u2028");  // match other JSON writers
-            } else if (ch == '\u2029') {
-                output.append("\\u2029");  // match other JSON writers
-            } else {
-                output.append(ch);
             }
+            output.append('"');
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
-        output.append('"');
     }
 
     //-----------------------------------------------------------------------
     /**
      * Writes a JSON array start.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeArrayStart() throws IOException {
-        output.append('[');
-        commaDepth++;
-        commaState.clear(commaDepth);
+    void writeArrayStart() {
+        try {
+            output.append('[');
+            commaDepth++;
+            commaState.clear(commaDepth);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
      * Writes a JSON array item start.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeArrayItemStart() throws IOException {
-        if (commaState.get(commaDepth)) {
-            output.append(',');
-            if (!newLine.isEmpty()) {
-                output.append(' ');
+    void writeArrayItemStart() {
+        try {
+            if (commaState.get(commaDepth)) {
+                output.append(',');
+                if (!newLine.isEmpty()) {
+                    output.append(' ');
+                }
+            } else {
+                commaState.set(commaDepth);
             }
-        } else {
-            commaState.set(commaDepth);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
     /**
      * Writes a JSON array end.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeArrayEnd() throws IOException {
-        output.append(']');
-        commaDepth--;
+    void writeArrayEnd() {
+        try {
+            output.append(']');
+            commaDepth--;
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     //-----------------------------------------------------------------------
     /**
      * Writes a JSON object start.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeObjectStart() throws IOException {
-        output.append('{');
-        currentIndent = currentIndent + indent;
-        commaDepth++;
-        commaState.set(commaDepth, false);
+    void writeObjectStart() {
+        try {
+            output.append('{');
+            currentIndent = currentIndent + indent;
+            commaDepth++;
+            commaState.set(commaDepth, false);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**
@@ -253,20 +298,24 @@ final class JsonOutput {
      * This handles the comma, string encoded key and separator colon.
      * 
      * @param key  the item key
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeObjectKey(String key) throws IOException {
-        if (commaState.get(commaDepth)) {
-            output.append(',');
-        } else {
-            commaState.set(commaDepth, true);
-        }
-        output.append(newLine);
-        output.append(currentIndent);
-        writeString(key);
-        output.append(':');
-        if (!newLine.isEmpty()) {
-            output.append(' ');
+    void writeObjectKey(String key) {
+        try {
+            if (commaState.get(commaDepth)) {
+                output.append(',');
+            } else {
+                commaState.set(commaDepth, true);
+            }
+            output.append(newLine);
+            output.append(currentIndent);
+            writeString(key);
+            output.append(':');
+            if (!newLine.isEmpty()) {
+                output.append(' ');
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
     }
 
@@ -275,9 +324,9 @@ final class JsonOutput {
      * 
      * @param key  the item key
      * @param value  the item value
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeObjectKeyValue(String key, String value) throws IOException {
+    void writeObjectKeyValue(String key, String value) {
         writeObjectKey(key);
         writeString(value);
     }
@@ -285,16 +334,20 @@ final class JsonOutput {
     /**
      * Writes a JSON object end.
      * 
-     * @throws IOException if an error occurs
+     * @throws UncheckedIOException if an error occurs
      */
-    void writeObjectEnd() throws IOException {
-        currentIndent = currentIndent.substring(0, currentIndent.length() - indent.length());
-        if (commaState.get(commaDepth)) {
-            output.append(newLine);
-            output.append(currentIndent);
+    void writeObjectEnd() {
+        try {
+            currentIndent = currentIndent.substring(0, currentIndent.length() - indent.length());
+            if (commaState.get(commaDepth)) {
+                output.append(newLine);
+                output.append(currentIndent);
+            }
+            output.append('}');
+            commaDepth--;
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
         }
-        output.append('}');
-        commaDepth--;
     }
 
 }

--- a/src/test/java/org/joda/beans/ser/json/TestJsonOutput.java
+++ b/src/test/java/org/joda/beans/ser/json/TestJsonOutput.java
@@ -17,8 +17,6 @@ package org.joda.beans.ser.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,7 +59,7 @@ public class TestJsonOutput {
 
     @ParameterizedTest
     @MethodSource("data_string")
-    public void test_writeString(String input, String expected) throws IOException {
+    public void test_writeString(String input, String expected) {
         outputCompact.writeString(input);
         assertThat(buf.toString()).isEqualTo('"' + expected + '"');
     }
@@ -80,7 +78,7 @@ public class TestJsonOutput {
 
     @ParameterizedTest
     @MethodSource("data_int")
-    public void test_writeInt(int input, String expected) throws IOException {
+    public void test_writeInt(int input, String expected) {
         outputCompact.writeInt(input);
         assertThat(buf.toString()).isEqualTo(expected);
     }
@@ -98,7 +96,7 @@ public class TestJsonOutput {
 
     @ParameterizedTest
     @MethodSource("data_long")
-    public void test_writeLong(long input, String expected) throws IOException {
+    public void test_writeLong(long input, String expected) {
         outputCompact.writeLong(input);
         assertThat(buf.toString()).isEqualTo(expected);
     }
@@ -121,7 +119,7 @@ public class TestJsonOutput {
 
     @ParameterizedTest
     @MethodSource("data_double")
-    public void test_writeDouble(double input, String expected) throws IOException {
+    public void test_writeDouble(double input, String expected) {
         outputCompact.writeDouble(input);
         assertThat(buf.toString()).isEqualTo(expected);
     }
@@ -144,40 +142,40 @@ public class TestJsonOutput {
 
     @ParameterizedTest
     @MethodSource("data_float")
-    public void test_writeFloat(float input, String expected) throws IOException {
+    public void test_writeFloat(float input, String expected) {
         outputCompact.writeFloat(input);
         assertThat(buf.toString()).isEqualTo(expected);
     }
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_writeNull() throws IOException {
+    public void test_writeNull() {
         outputCompact.writeNull();
         assertThat(buf.toString()).isEqualTo("null");
     }
 
     @Test
-    public void test_writeBoolean_true() throws IOException {
+    public void test_writeBoolean_true() {
         outputCompact.writeBoolean(true);
         assertThat(buf.toString()).isEqualTo("true");
     }
 
     @Test
-    public void test_writeBoolean_false() throws IOException {
+    public void test_writeBoolean_false() {
         outputCompact.writeBoolean(false);
         assertThat(buf.toString()).isEqualTo("false");
     }
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_write_array0() throws IOException {
+    public void test_write_array0() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayEnd();
         assertThat(buf.toString()).isEqualTo("[]");
     }
 
     @Test
-    public void test_write_array1() throws IOException {
+    public void test_write_array1() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -186,7 +184,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_array2() throws IOException {
+    public void test_write_array2() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -197,7 +195,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_array3() throws IOException {
+    public void test_write_array3() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -210,7 +208,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep0() throws IOException {
+    public void test_write_arrayDeep0() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -224,7 +222,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep1() throws IOException {
+    public void test_write_arrayDeep1() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -240,7 +238,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep2() throws IOException {
+    public void test_write_arrayDeep2() {
         outputCompact.writeArrayStart();
         outputCompact.writeArrayItemStart();
         outputCompact.writeString("a");
@@ -259,14 +257,14 @@ public class TestJsonOutput {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_write_object0() throws IOException {
+    public void test_write_object0() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectEnd();
         assertThat(buf.toString()).isEqualTo("{}");
     }
 
     @Test
-    public void test_write_object1() throws IOException {
+    public void test_write_object1() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKey("a");
         outputCompact.writeString("aa");
@@ -275,7 +273,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_object2() throws IOException {
+    public void test_write_object2() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKey("a");
         outputCompact.writeString("aa");
@@ -286,7 +284,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_object3() throws IOException {
+    public void test_write_object3() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKeyValue("a", "aa");
         outputCompact.writeObjectKeyValue("b", "bb");
@@ -296,7 +294,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep0() throws IOException {
+    public void test_write_objectDeep0() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKeyValue("a", "aa");
         outputCompact.writeObjectKey("b");
@@ -308,7 +306,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep1() throws IOException {
+    public void test_write_objectDeep1() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKeyValue("a", "aa");
         outputCompact.writeObjectKey("b");
@@ -321,7 +319,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep2() throws IOException {
+    public void test_write_objectDeep2() {
         outputCompact.writeObjectStart();
         outputCompact.writeObjectKeyValue("a", "aa");
         outputCompact.writeObjectKey("b");
@@ -336,14 +334,14 @@ public class TestJsonOutput {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_write_array0_pretty() throws IOException {
+    public void test_write_array0_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayEnd();
         assertThat(buf.toString()).isEqualTo("[]");
     }
 
     @Test
-    public void test_write_array1_pretty() throws IOException {
+    public void test_write_array1_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -352,7 +350,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_array2_pretty() throws IOException {
+    public void test_write_array2_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -363,7 +361,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_array3_pretty() throws IOException {
+    public void test_write_array3_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -376,7 +374,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep0_pretty() throws IOException {
+    public void test_write_arrayDeep0_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -390,7 +388,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep1_pretty() throws IOException {
+    public void test_write_arrayDeep1_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -406,7 +404,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_arrayDeep2_pretty() throws IOException {
+    public void test_write_arrayDeep2_pretty() {
         outputPretty.writeArrayStart();
         outputPretty.writeArrayItemStart();
         outputPretty.writeString("a");
@@ -425,14 +423,14 @@ public class TestJsonOutput {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_write_object0_pretty() throws IOException {
+    public void test_write_object0_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectEnd();
         assertThat(buf.toString()).isEqualTo("{}");
     }
 
     @Test
-    public void test_write_object1_pretty() throws IOException {
+    public void test_write_object1_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKey("a");
         outputPretty.writeString("aa");
@@ -441,7 +439,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_object2_pretty() throws IOException {
+    public void test_write_object2_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKey("a");
         outputPretty.writeString("aa");
@@ -452,7 +450,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_object3_pretty() throws IOException {
+    public void test_write_object3_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKeyValue("a", "aa");
         outputPretty.writeObjectKeyValue("b", "bb");
@@ -462,7 +460,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep0_pretty() throws IOException {
+    public void test_write_objectDeep0_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKeyValue("a", "aa");
         outputPretty.writeObjectKey("b");
@@ -474,7 +472,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep1_pretty() throws IOException {
+    public void test_write_objectDeep1_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKeyValue("a", "aa");
         outputPretty.writeObjectKey("b");
@@ -487,7 +485,7 @@ public class TestJsonOutput {
     }
 
     @Test
-    public void test_write_objectDeep2_pretty() throws IOException {
+    public void test_write_objectDeep2_pretty() {
         outputPretty.writeObjectStart();
         outputPretty.writeObjectKeyValue("a", "aa");
         outputPretty.writeObjectKey("b");


### PR DESCRIPTION
* Retain the public API, but change the internals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in JSON writing operations, improving robustness and user experience.
  
- **Bug Fixes**
	- Streamlined exception handling by centralising error management within methods, reducing the need for callers to manage checked exceptions.

- **Tests**
	- Updated test methods to reflect changes in error handling, removing the `throws IOException` clause for better clarity and simplicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->