### PR TITLE
Fix BeanAssert

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -29,6 +29,10 @@
         This is a much more natural JSON format.
         The old format cam still be parsed successfully.
       </action>
+      <action dev="jodastephen" type="fix">
+        Fix `BeanAssert` to output the correct message.
+        Previously there was no check for equals at the property level, nor were arrays properly converted to `String`.
+      </action>
     </release>
     <release version="2.12.0" date="SNAPSHOT" description="v2.12.0">
       <action dev="jodastephen" type="fix" issue="424">

--- a/src/main/java/org/joda/beans/test/BeanAssert.java
+++ b/src/main/java/org/joda/beans/test/BeanAssert.java
@@ -16,7 +16,6 @@
 package org.joda.beans.test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -216,6 +215,9 @@ public final class BeanAssert {
             diffs.add(prefix + ": Was null, but expected " + buildSummary(expected, true));
             return;
         }
+        if (expected.equals(actual)) {
+            return;
+        }
         if (expected instanceof List<?> expectedList && actual instanceof List<?> actualList) {
             if (expectedList.size() != actualList.size()) {
                 diffs.add(prefix + ": List size differs, expected " + expectedList.size() + " but was " + actualList.size());
@@ -311,11 +313,7 @@ public final class BeanAssert {
      */
     private static String buildSummary(Object obj, boolean includeType) {
         var type = obj.getClass().getSimpleName();
-        var toStr = switch (obj) {
-            case double[] arr -> Arrays.toString(arr);
-            case float[] arr -> Arrays.toString(arr);
-            default -> obj.toString();
-        };
+        var toStr = JodaBeanUtils.toString(obj);
         if (toStr.length() > 60) {
             toStr = toStr.substring(0, 57) + "...";
         }


### PR DESCRIPTION
* Fix message to handle arrays correctly
* Fix output to handle equals at the property level correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality in the `BeanAssert` class for better equality checks and error reporting.
	- Improved handling of JSON serialization for 2-dimensional primitive arrays.

- **Bug Fixes**
	- Corrected output messages and checks in the `BeanAssert` class.
	- Resolved issues related to boolean arrays and property name clashes.

- **Compatibility Updates**
	- Major version change to support Java SE 21 and removal of deprecated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->