### PR TITLE
Cache ResolvedType in MetaProperty

### DIFF
--- a/src/main/java/org/joda/beans/MetaProperty.java
+++ b/src/main/java/org/joda/beans/MetaProperty.java
@@ -89,9 +89,21 @@ public interface MetaProperty<P> {
      * <p>
      * This provides access to the generic type declared in the source code.
      * 
-     * @return the full generic type of the property, unmodifiable, not null
+     * @return the full generic type of the property, not null
      */
     public abstract Type propertyGenericType();
+
+    /**
+     * Gets the resolved generic type of the property.
+     * <p>
+     * This provides access to the generic type resolved relative to the context class.
+     * 
+     * @param contextClass  the context class, typically the bean implementation class
+     * @return the resolved generic type of the property, not null
+     */
+    public default ResolvedType propertyResolvedType(Class<?> contextClass) {
+        return ResolvedType.from(propertyGenericType(), contextClass);
+    }
 
     /**
      * Gets the style of the property, such as read-only, read-write or write-only.

--- a/src/main/java/org/joda/beans/ResolvedType.java
+++ b/src/main/java/org/joda/beans/ResolvedType.java
@@ -473,12 +473,23 @@ public final class ResolvedType {
 
     //-------------------------------------------------------------------------
     /**
+     * Checks whether this is a parameterized generic type, irrespective of whether the type arguments are known.
+     * <p>
+     * For example, "List" and "List&lt;String&gt;" return true, while "String" returns false.
+     * 
+     * @return true if this is a type with generic type parameters
+     */
+    public boolean isParameterized() {
+        return rawType.getTypeParameters().length != 0;
+    }
+
+    /**
      * Checks whether this is a raw type.
      * 
-     * @return true if this is a generified type (with type parameters) and the type arguments are empty
+     * @return true if this is a parameterized generic type but the type arguments are empty
      */
     public boolean isRaw() {
-        return arguments.isEmpty() && rawType.getTypeParameters().length != 0;
+        return arguments.isEmpty() && isParameterized();
     }
 
     /**

--- a/src/main/java/org/joda/beans/impl/direct/MinimalMetaProperty.java
+++ b/src/main/java/org/joda/beans/impl/direct/MinimalMetaProperty.java
@@ -18,6 +18,7 @@ package org.joda.beans.impl.direct;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,7 @@ import org.joda.beans.Bean;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.MetaBean;
 import org.joda.beans.PropertyStyle;
+import org.joda.beans.ResolvedType;
 import org.joda.beans.impl.BasicMetaProperty;
 
 /**
@@ -43,6 +45,8 @@ final class MinimalMetaProperty<P> extends BasicMetaProperty<P> {
     private final Class<P> propertyType;
     /** The type of the property. */
     private final Type propertyGenericType;
+    /** The function to create the resolved type of the property. */
+    private final Function<Class<?>, ResolvedType> propertyResolvedTypeFn;
     /** The annotations. */
     private final List<Annotation> annotations;
     /** The read method. */
@@ -82,6 +86,7 @@ final class MinimalMetaProperty<P> extends BasicMetaProperty<P> {
         } else {
             this.style = setter != null ? PropertyStyle.READ_WRITE : PropertyStyle.READ_ONLY;
         }
+        this.propertyResolvedTypeFn = createResolvedTypeFunction();
     }
 
     /**
@@ -113,6 +118,15 @@ final class MinimalMetaProperty<P> extends BasicMetaProperty<P> {
         };
         this.setter = null;
         this.style = PropertyStyle.DERIVED;
+        this.propertyResolvedTypeFn = createResolvedTypeFunction();
+    }
+
+    private Function<Class<?>, ResolvedType> createResolvedTypeFunction() {
+        var beanType = metaBean.beanType();
+        var resolvedType = ResolvedType.from(propertyGenericType, beanType);
+        return !resolvedType.isParameterized() || Modifier.isFinal(beanType.getModifiers()) ?
+                contextClass -> resolvedType :
+                contextClass -> contextClass == beanType ? resolvedType : ResolvedType.from(propertyGenericType, contextClass);
     }
 
     //-----------------------------------------------------------------------
@@ -134,6 +148,11 @@ final class MinimalMetaProperty<P> extends BasicMetaProperty<P> {
     @Override
     public Type propertyGenericType() {
         return propertyGenericType;
+    }
+
+    @Override
+    public ResolvedType propertyResolvedType(Class<?> contextClass) {
+        return propertyResolvedTypeFn.apply(contextClass);
     }
 
     @Override

--- a/src/main/java/org/joda/beans/impl/light/LightMetaProperty.java
+++ b/src/main/java/org/joda/beans/impl/light/LightMetaProperty.java
@@ -25,11 +25,13 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 import org.joda.beans.Bean;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.MetaBean;
 import org.joda.beans.PropertyStyle;
+import org.joda.beans.ResolvedType;
 import org.joda.beans.impl.BasicMetaProperty;
 
 /**
@@ -45,6 +47,8 @@ final class LightMetaProperty<P> extends BasicMetaProperty<P> {
     private final Class<P> propertyType;
     /** The type of the property. */
     private final Type propertyGenericType;
+    /** The function to create the resolved type of the property. */
+    private final Function<Class<?>, ResolvedType> propertyResolvedTypeFn;
     /** The annotations. */
     private final List<Annotation> annotations;
     /** The read method. */
@@ -222,6 +226,11 @@ final class LightMetaProperty<P> extends BasicMetaProperty<P> {
         this.setter = setter != null ? setter.asType(MethodType.methodType(void.class, Bean.class, Object.class)) : null;
         this.constructorIndex = constructorIndex;
         this.style = style;
+        var beanType = metaBean.beanType();
+        var resolvedType = ResolvedType.from(propertyGenericType, beanType);
+        this.propertyResolvedTypeFn = !resolvedType.isParameterized() || Modifier.isFinal(beanType.getModifiers()) ?
+                contextClass -> resolvedType :
+                contextClass -> contextClass == beanType ? resolvedType : ResolvedType.from(propertyGenericType, contextClass);
     }
 
     //-----------------------------------------------------------------------
@@ -243,6 +252,11 @@ final class LightMetaProperty<P> extends BasicMetaProperty<P> {
     @Override
     public Type propertyGenericType() {
         return propertyGenericType;
+    }
+
+    @Override
+    public ResolvedType propertyResolvedType(Class<?> contextClass) {
+        return propertyResolvedTypeFn.apply(contextClass);
     }
 
     @Override

--- a/src/test/java/org/joda/beans/TestResolvedType.java
+++ b/src/test/java/org/joda/beans/TestResolvedType.java
@@ -263,6 +263,7 @@ public class TestResolvedType {
         }
         assertThat(test.toArrayType().toComponentType()).isEqualTo(test);
         assertThat(test.isPrimitive()).isEqualTo(expectedRawType.isPrimitive());
+        assertThat(test.isParameterized()).isEqualTo(expectedRawType.getTypeParameters().length > 0);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Statically defined meta-properties can cache the resolved type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for enhanced type resolution in property management.
	- Added functionality to check if a type is parameterized.

- **Bug Fixes**
	- Updated documentation for existing methods to clarify their behaviour.

- **Tests**
	- Enhanced test coverage by adding assertions to validate parameterized types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->