### PR TITLE
More ResolvedType methods

### DIFF
--- a/src/main/java/org/joda/beans/ResolvedType.java
+++ b/src/main/java/org/joda/beans/ResolvedType.java
@@ -521,6 +521,40 @@ public final class ResolvedType {
     }
 
     /**
+     * Returns the boxed type equivalent to this type.
+     * <p>
+     * If this type is one of the nine primitive types, the equivalent box is returned.
+     * Otherwise, {@code this} is returned.
+     * 
+     * @return the equivalent boxed type
+     */
+    public ResolvedType toBoxed() {
+        return rawType.isPrimitive() ? boxed() : this;
+    }
+
+    private ResolvedType boxed() {
+        if (rawType == int.class) {
+            return ResolvedType.of(Integer.class);
+        } else if (rawType == long.class) {
+            return ResolvedType.of(Long.class);
+        } else if (rawType == double.class) {
+            return ResolvedType.of(Double.class);
+        } else if (rawType == boolean.class) {
+            return ResolvedType.of(Boolean.class);
+        } else if (rawType == byte.class) {
+            return ResolvedType.of(Byte.class);
+        } else if (rawType == char.class) {
+            return ResolvedType.of(Character.class);
+        } else if (rawType == short.class) {
+            return ResolvedType.of(Short.class);
+        } else if (rawType == float.class) {
+            return ResolvedType.of(Float.class);
+        } else {
+            return ResolvedType.of(Void.class);
+        }
+    }
+
+    /**
      * Gets the component type if the raw type is an array.
      * <p>
      * Note that the component type may be an array type if this type is a higher-dimension array.
@@ -538,6 +572,21 @@ public final class ResolvedType {
 
     private IllegalStateException invalidArrayType() {
         return new IllegalStateException("Unable to get component type for " + this + ", type is not an array");
+    }
+
+    /**
+     * Gets the component type if the raw type is an array, defaulting to {@code Object} if the type is not an array.
+     * <p>
+     * Note that the component type may be an array type if this type is a higher-dimension array.
+     * 
+     * @return the component type
+     */
+    public ResolvedType toComponentTypeOrDefault() {
+        var componentType = rawType.getComponentType();
+        if (componentType == null) {
+            return ResolvedType.OBJECT;
+        }
+        return new ResolvedType(componentType, arguments);
     }
 
     /**

--- a/src/test/java/org/joda/beans/TestResolvedType.java
+++ b/src/test/java/org/joda/beans/TestResolvedType.java
@@ -255,11 +255,14 @@ public class TestResolvedType {
             assertThat(test.isArray()).isTrue();
             assertThat(test.toComponentType())
                     .isEqualTo(ResolvedType.of(expectedRawType.getComponentType(), test.getArguments().toArray(new ResolvedType[0])));
+            assertThat(test.toComponentTypeOrDefault())
+                    .isEqualTo(ResolvedType.of(expectedRawType.getComponentType(), test.getArguments().toArray(new ResolvedType[0])));
         } else {
             assertThat(test.isArray()).isFalse();
             assertThatIllegalStateException()
                     .isThrownBy(() -> test.toComponentType())
                     .withMessage("Unable to get component type for " + expectedToString + ", type is not an array");
+            assertThat(test.toComponentTypeOrDefault()).isEqualTo(ResolvedType.OBJECT);
         }
         assertThat(test.toArrayType().toComponentType()).isEqualTo(test);
         assertThat(test.isPrimitive()).isEqualTo(expectedRawType.isPrimitive());
@@ -280,6 +283,32 @@ public class TestResolvedType {
         assertThat(obj).isEqualTo(test);
     }
 
+    //-------------------------------------------------------------------------
+    @SuppressWarnings("serial")
+    static Object[][] data_boxed() {
+        return new Object[][] {
+                {String.class, String.class},
+                {long.class, Long.class},
+                {int.class, Integer.class},
+                {short.class, Short.class},
+                {byte.class, Byte.class},
+                {double.class, Double.class},
+                {float.class, Float.class},
+                {char.class, Character.class},
+                {boolean.class, Boolean.class},
+                {void.class, Void.class},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("data_boxed")
+    void test_boxed(Class<?> primitive, Class<?> box) {
+        var test = ResolvedType.of(primitive);
+        assertThat(test.isPrimitive()).isEqualTo(primitive != String.class);
+        assertThat(test.toBoxed()).isEqualTo(ResolvedType.of(box));
+    }
+
+    //-------------------------------------------------------------------------
     @SuppressWarnings("serial")
     static Object[][] data_invalidParse() {
         return new Object[][] {


### PR DESCRIPTION
* Add method to box a primitive type
* Add method to get the array component type or a default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for enhanced type handling: `toBoxed()` for converting primitive types to boxed types, and `toComponentTypeOrDefault()` for retrieving array component types.
  
- **Bug Fixes**
	- Improved test coverage for type resolution, ensuring correct behaviour for both array and non-array types in existing tests.

- **Tests**
	- Added new parameterised tests to validate the functionality of boxed type conversions and enhanced assertions in existing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->