### PR TITLE
Add a binary format enum

### DIFF
--- a/src/main/java/org/joda/beans/ser/JodaBeanSer.java
+++ b/src/main/java/org/joda/beans/ser/JodaBeanSer.java
@@ -17,6 +17,7 @@ package org.joda.beans.ser;
 
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaProperty;
+import org.joda.beans.ser.bin.JodaBeanBinFormat;
 import org.joda.beans.ser.bin.JodaBeanBinReader;
 import org.joda.beans.ser.bin.JodaBeanBinWriter;
 import org.joda.beans.ser.json.JodaBeanJsonReader;
@@ -88,7 +89,11 @@ public final class JodaBeanSer {
      * @param deserializers  the deserializers to use, not null
      */
     private JodaBeanSer(String indent, String newLine, StringConvert converter,
-                SerIteratorFactory iteratorFactory, boolean shortTypes, SerDeserializers deserializers, boolean includeDerived) {
+            SerIteratorFactory iteratorFactory,
+            boolean shortTypes,
+            SerDeserializers deserializers,
+            boolean includeDerived) {
+
         this.indent = indent;
         this.newLine = newLine;
         this.converter = converter;
@@ -248,12 +253,13 @@ public final class JodaBeanSer {
      * This is used to set the output to include derived properties.
      * 
      * @param includeDerived  whether to include derived properties on output
-     * @return a copy of this object with the converter changed, not null
+     * @return a copy of this object with the derived flag changed, not null
      */
     public JodaBeanSer withIncludeDerived(boolean includeDerived) {
         return new JodaBeanSer(indent, newLine, converter, iteratorFactory, shortTypes, deserializers, includeDerived);
     }
 
+    //-------------------------------------------------------------------------
     /**
      * Checks if the property is serialized.
      * 
@@ -287,7 +293,20 @@ public final class JodaBeanSer {
      * @return the binary writer, not null
      */
     public JodaBeanBinWriter binWriter() {
-        return new JodaBeanBinWriter(this, false);
+        return new JodaBeanBinWriter(this, JodaBeanBinFormat.STANDARD);
+    }
+
+    /**
+     * Creates a binary writer using the specified format.
+     * <p>
+     * It is recommended, though not necessary, to create a new instance of the writer for each message.
+     * 
+     * @param format  the format, not null
+     * @return the binary writer, not null
+     * @since 3.0.0
+     */
+    public JodaBeanBinWriter binWriter(JodaBeanBinFormat format) {
+        return new JodaBeanBinWriter(this, format);
     }
 
     /**
@@ -305,13 +324,15 @@ public final class JodaBeanSer {
      * The reader {@link #binReader()} handles both the standard and referencing formats.
      * 
      * @return the referencing binary writer, not null
+     * @deprecated Pass the format explicitly 
      */
+    @Deprecated
     public JodaBeanBinWriter binWriterReferencing() {
-        return new JodaBeanBinWriter(this, true);
+        return new JodaBeanBinWriter(this, JodaBeanBinFormat.REFERENCING);
     }
 
     /**
-     * Creates a binary reader that handles both the standard and referencing binary formats.
+     * Creates a binary reader that handles all binary formats that can be written.
      * <p>
      * It is recommended, though not necessary, to create a new instance of the reader for each message.
      * 

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser.bin;
+
+/**
+ * Provides control over the binary format.
+ * 
+ * @since 3.0.0
+ */
+public enum JodaBeanBinFormat {
+
+    /**
+     * The Standard format, version 1
+     * <p>
+     * The binary format is based on MessagePack v2.0.
+     * Each bean is output as a map using the property name.
+     * <p>
+     * Most simple types, defined by Joda-Convert, are output as MessagePack strings.
+     * However, MessagePack nil, boolean, float, integral and bin types are also used
+     * for null, byte[] and the Java numeric primitive types (excluding char).
+     * <p>
+     * Beans are output using MessagePack maps where the key is the property name.
+     * Collections are output using MessagePack maps or arrays.
+     * Multisets are output as a map of value to count.
+     * <p>
+     * If a collection contains a collection then addition meta-type information is
+     * written to aid with deserialization.
+     * At this level, the data read back may not be identical to that written.
+     * <p>
+     * Where necessary, the Java type is sent using an 'ext' entity.
+     * Three 'ext' types are used, one each for beans, meta-type and simple.
+     * The class name is passed as the 'ext' data.
+     * The 'ext' value is sent as an additional key-value pair for beans, with the
+     * 'ext' as the key and 'nil' as the value. Where the additional type information
+     * is not about a bean, a tuple is written using a size 1 map where the key is the
+     * 'ext' data and the value is the data being annotated.
+     * <p>
+     * Type names are shortened by the package of the root type if possible.
+     * Certain basic types are also handled, such as String, Integer, File and URI.
+     */
+    STANDARD(1),
+    /**
+     * The Referencing format, version 2
+     * <p>
+     * The referencing format is based on the standard format.
+     * As a more complex format, it is intended to be consumed only by Joda-Beans
+     * (whereas the standard format could be consumed by any consumer using MsgPack).
+     * Thus this format is not fully documented and may change over time.
+     * <p>
+     * The referencing format only supports serialization of instances of {@code ImmutableBean}
+     * and other basic types. If any mutable beans are encountered during traversal an exception will be thrown.
+     * <p>
+     * An initial pass of the bean is used to build up a map of unique immutable beans
+     * and unique immutable instances of other classes (based on an equality check).
+     * Then the class and property names for each bean class is serialized up front as a map of class name to list of
+     * property names, along with class information for any class where type information would be required when parsing
+     * and is not available on the metabean for the enclosing bean object.
+     * <p>
+     * Each unique immutable bean is output as a list of each property value using the fixed
+     * property order previously serialized. Subsequent instances of unique objects (defined by an
+     * equality check) are replaced by references to the first serialized instance.
+     * <p>
+     * The Java type names are sent using an 'ext' entity.
+     * Five 'ext' types are used, one each for beans, meta-type and simple, reference keys and reference lookups.
+     * The class name is passed as the 'ext' data.
+     * The 'ext' value is sent as the first item in an array of property values for beans, an integer referring to the
+     * location in the initial class mapping.
+     * Where the additional type information is not about a bean, a tuple is written using a size 1 map where the key is
+     * the 'ext' data and the value is the data being annotated.
+     * <p>
+     * For references, when an object will be referred back to it is written as a map of size one with 'ext' as the key
+     * and the object that should be referred to as the value.
+     * When that same object is referred back to it is written as 'ext' with the data from the initial 'ext'.
+     */
+    REFERENCING(2);
+
+    /**
+     * The format version.
+     */
+    private final int version;
+
+    private JodaBeanBinFormat(int version) {
+        this.version = version;
+    }
+
+    /**
+     * Returns the version number used to identify the format in the file.
+     * 
+     * @return the version
+     */
+    public int version() {
+        return version;
+    }
+
+}

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinWriter.java
@@ -15,77 +15,23 @@
  */
 package org.joda.beans.ser.bin;
 
+import static org.joda.beans.ser.bin.JodaBeanBinFormat.REFERENCING;
+import static org.joda.beans.ser.bin.JodaBeanBinFormat.STANDARD;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 
 import org.joda.beans.Bean;
-import org.joda.beans.ImmutableBean;
 import org.joda.beans.ser.JodaBeanSer;
 
 /**
  * Provides the ability for a Joda-Bean to be written to a binary format.
  * <p>
  * This class is immutable and may be used from multiple threads.
- * 
- * <h3>Standard format</h3>
- * The binary format is based on MessagePack v2.0.
- * Each bean is output as a map using the property name.
  * <p>
- * Most simple types, defined by Joda-Convert, are output as MessagePack strings.
- * However, MessagePack nil, boolean, float, integral and bin types are also used
- * for null, byte[] and the Java numeric primitive types (excluding char).
- * <p>
- * Beans are output using MessagePack maps where the key is the property name.
- * Collections are output using MessagePack maps or arrays.
- * Multisets are output as a map of value to count.
- * <p>
- * If a collection contains a collection then addition meta-type information is
- * written to aid with deserialization.
- * At this level, the data read back may not be identical to that written.
- * <p>
- * Where necessary, the Java type is sent using an 'ext' entity.
- * Three 'ext' types are used, one each for beans, meta-type and simple.
- * The class name is passed as the 'ext' data.
- * The 'ext' value is sent as an additional key-value pair for beans, with the
- * 'ext' as the key and 'nil' as the value. Where the additional type information
- * is not about a bean, a tuple is written using a size 1 map where the key is the
- * 'ext' data and the value is the data being annotated.
- * <p>
- * Type names are shortened by the package of the root type if possible.
- * Certain basic types are also handled, such as String, Integer, File and URI.
- * 
- * <h3>Referencing format</h3>
- * The referencing format is based on the standard format.
- * As a more complex format, it is intended to be consumed only by Joda-Beans
- * (whereas the standard format could be consumed by any consumer using MsgPack).
- * Thus this format is not fully documented and may change over time.
- * <p>
- * The referencing format only supports serialization of instances of {@code ImmutableBean}
- * and other basic types. If any mutable beans are encountered during traversal an exception will be thrown.
- * <p>
- * An initial pass of the bean is used to build up a map of unique immutable beans
- * and unique immutable instances of other classes (based on an equality check).
- * Then the class and property names for each bean class is serialized up front as a map of class name to list of
- * property names, along with class information for any class where type information would be required when parsing
- * and is not available on the metabean for the enclosing bean object.
- * <p>
- * Each unique immutable bean is output as a list of each property value using the fixed
- * property order previously serialized. Subsequent instances of unique objects (defined by an
- * equality check) are replaced by references to the first serialized instance.
- * <p>
- * The Java type names are sent using an 'ext' entity.
- * Five 'ext' types are used, one each for beans, meta-type and simple, reference keys and reference lookups.
- * The class name is passed as the 'ext' data.
- * The 'ext' value is sent as the first item in an array of property values for beans, an integer referring to the
- * location in the initial class mapping.
- * Where the additional type information is not about a bean, a tuple is written using a size 1 map where the key is
- * the 'ext' data and the value is the data being annotated.
- * <p>
- * For references, when an object will be referred back to it is written as a map of size one with 'ext' as the key
- * and the object that should be referred to as the value.
- * When that same object is referred back to it is written as 'ext' with the data from the initial 'ext'.
+ * See {@link JodaBeanBinFormat} for details on each file format.
  */
 public class JodaBeanBinWriter {
 
@@ -94,9 +40,9 @@ public class JodaBeanBinWriter {
      */
     private final JodaBeanSer settings;
     /**
-     * Whether to use referencing.
+     * The format.
      */
-    private final boolean referencing;
+    private final JodaBeanBinFormat format;
 
     //-----------------------------------------------------------------------
     /**
@@ -105,7 +51,7 @@ public class JodaBeanBinWriter {
      * @param settings  the settings to use, not null
      */
     public JodaBeanBinWriter(JodaBeanSer settings) {
-        this(settings, false);
+        this(settings, STANDARD);
     }
 
     /**
@@ -113,10 +59,24 @@ public class JodaBeanBinWriter {
      * 
      * @param settings  the settings to use, not null
      * @param referencing  whether to use referencing
+     * @deprecated Use the format instead of the boolean flag
      */
+    @Deprecated
     public JodaBeanBinWriter(JodaBeanSer settings, boolean referencing) {
         this.settings = Objects.requireNonNull(settings, "settings must not be null");
-        this.referencing = referencing;
+        this.format = referencing ? REFERENCING : STANDARD;
+    }
+
+    /**
+     * Creates an instance.
+     * 
+     * @param settings  the settings to use, not null
+     * @param format  the format, not null
+     * @since 3.0.0
+     */
+    public JodaBeanBinWriter(JodaBeanSer settings, JodaBeanBinFormat format) {
+        this.settings = Objects.requireNonNull(settings, "settings must not be null");
+        this.format = Objects.requireNonNull(format, "format must not be null");
     }
 
     //-----------------------------------------------------------------------
@@ -166,21 +126,17 @@ public class JodaBeanBinWriter {
      * Writes the bean to the {@code OutputStream}.
      * 
      * @param bean  the bean to output, not null
-     * @param rootType  true to output the root type
+     * @param includeRootType  true to output the root type
      * @param output  the output stream, not null
      * @throws IOException if an error occurs
      */
-    public void write(Bean bean, boolean rootType, OutputStream output) throws IOException {
+    public void write(Bean bean, boolean includeRootType, OutputStream output) throws IOException {
         Objects.requireNonNull(bean, "bean must not be null");
         Objects.requireNonNull(output, "output must not be null");
-        if (referencing) {
-            if (!(bean instanceof ImmutableBean)) {
-                throw new IllegalArgumentException(
-                    "Referencing binary format can only write ImmutableBean instances: " + bean.getClass().getName());
-            }
-            new JodaBeanReferencingBinWriter(settings, output).write((ImmutableBean) bean);
-        } else {
-            new JodaBeanStandardBinWriter(settings, output).write(bean, rootType);
+        switch (format) {
+            case STANDARD -> new JodaBeanStandardBinWriter(settings, output).write(bean, includeRootType);
+            case REFERENCING -> new JodaBeanReferencingBinWriter(settings, output).write(bean);
+            default -> throw new IllegalArgumentException("Invalid bin format, must be 1 or 2");
         }
     }
 

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanReferencingBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanReferencingBinWriter.java
@@ -39,9 +39,13 @@ class JodaBeanReferencingBinWriter extends AbstractBinWriter {
 
     //-----------------------------------------------------------------------
     // writes the bean
-    void write(ImmutableBean bean) throws IOException {
+    void write(Bean bean) throws IOException {
+        if (!(bean instanceof ImmutableBean immutable)) {
+            throw new IllegalArgumentException(
+                    "Referencing binary format can only write ImmutableBean instances: " + bean.getClass().getName());
+        }
         // sets up the map of beans - classes & classSerializationCount
-        references = BeanReferences.find(bean, settings);
+        references = BeanReferences.find(immutable, settings);
 
         // write array of 4 items - Version, Ref Count, Class Info, Root Bean
         output.writeArrayHeader(4);

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanStandardBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanStandardBinWriter.java
@@ -17,7 +17,6 @@ package org.joda.beans.ser.bin;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
@@ -115,15 +114,11 @@ final class JodaBeanStandardBinWriter {
      * @throws IOException if an error occurs
      */
     void write(Bean bean, boolean includeRootType) throws IOException {
-        try {
-            var rootType = includeRootType ? ResolvedType.OBJECT : ResolvedType.of(bean.getClass());
-            output.writeArrayHeader(2);
-            output.writeInt(1);  // version 1
-            // root always outputs the bean, not Joda-Convert form
-            writeBean(rootType, "", bean, true);
-        } catch (UncheckedIOException ex) {
-            throw ex.getCause();
-        }
+        var rootType = includeRootType ? ResolvedType.OBJECT : ResolvedType.of(bean.getClass());
+        output.writeArrayHeader(2);
+        output.writeInt(1);  // version 1
+        // root always outputs the bean, not Joda-Convert form
+        writeBean(rootType, "", bean, true);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/beans/ser/SerTestHelper.java
+++ b/src/test/java/org/joda/beans/ser/SerTestHelper.java
@@ -102,7 +102,7 @@ public class SerTestHelper {
         return address;
     }
 
-    public static ImmAddress testImmAddress(boolean immutable) {
+    public static ImmAddress testImmAddress(boolean isImmutable) {
         Map<String, List<String>> map = new HashMap<>();
         map.put("A", Arrays.asList("B", "b"));
         Map<String, List<Integer>> map2 = new HashMap<>();
@@ -121,7 +121,7 @@ public class SerTestHelper {
         primitives.setValueChar('7');
         primitives.setValueBoolean(true);
         List<Object> objects1 = Arrays.<Object>asList(Currency.getInstance("GBP"), TimeZone.getTimeZone("Europe/London"));
-        List<Object> objects2 = immutable ?
+        List<Object> objects2 = isImmutable ?
                 Arrays.<Object>asList(Locale.CANADA_FRENCH, Long.valueOf(2)) :
                 Arrays.<Object>asList(Locale.CANADA_FRENCH, Long.valueOf(2), primitives);
         map5.put("A", Arrays.asList(objects1));
@@ -135,7 +135,7 @@ public class SerTestHelper {
                 .forename("Etienne")
                 .middleNames("K", "T")
                 .surname("Colebourne")
-                .addressList(immutable ? null : Arrays.asList(new Address()))
+                .addressList(isImmutable ? null : Arrays.asList(new Address()))
                 .codeCounts(ImmutableMultiset.of("A", "A", "B"))
                 .build();
         ImmPerson child = ImmPerson.builder()

--- a/src/test/java/org/joda/beans/ser/TestJodaBeanBinFormat.java
+++ b/src/test/java/org/joda/beans/ser/TestJodaBeanBinFormat.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.joda.beans.ser.bin.JodaBeanBinFormat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link JodaBeanBinFormat}.
+ */
+class TestJodaBeanBinFormat {
+
+    @Test
+    void test() {
+        assertThat(JodaBeanBinFormat.STANDARD.version()).isEqualTo(1);
+        assertThat(JodaBeanBinFormat.REFERENCING.version()).isEqualTo(2);
+    }
+
+}

--- a/src/test/java/org/joda/beans/ser/TestSerDeserializerProvider.java
+++ b/src/test/java/org/joda/beans/ser/TestSerDeserializerProvider.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test ser.
  */
-public class TestSerDeserializerProvider {
+class TestSerDeserializerProvider {
 
     private static final SerDeserializer DESER = new SerDeserializer() {
         
@@ -66,13 +66,13 @@ public class TestSerDeserializerProvider {
     };
 
     @Test
-    public void test_provider() {
+    void test_provider() {
         SerDeserializers deser = new SerDeserializers(PROVIDER);
         assertThat(deser.findDeserializer(Person.class)).isSameAs(DESER);
     }
 
     @Test
-    public void test_classpathImmKey() {
+    void test_classpathImmKey() {
         assertThat(SerDeserializers.INSTANCE.getDeserializers()).containsKey(ImmKey.class);
         assertThat(SerDeserializers.LENIENT.getDeserializers()).containsKey(ImmKey.class);
         assertThat(new SerDeserializers(PROVIDER).getDeserializers()).containsKey(ImmKey.class);
@@ -84,7 +84,7 @@ public class TestSerDeserializerProvider {
     }
 
     @Test
-    public void test_classpathPair() {
+    void test_classpathPair() {
         assertThat(SerDeserializers.INSTANCE.getDeserializers()).containsKey(Pair.class);
         assertThat(SerDeserializers.LENIENT.getDeserializers()).containsKey(Pair.class);
         assertThat(new SerDeserializers(PROVIDER).getDeserializers()).containsKey(Pair.class);

--- a/src/test/java/org/joda/beans/ser/TestSerTypeMapper.java
+++ b/src/test/java/org/joda/beans/ser/TestSerTypeMapper.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Test ser.
  */
-public class TestSerTypeMapper {
+class TestSerTypeMapper {
 
     private static final JodaBeanSer SETTINGS = JodaBeanSer.PRETTY;
     private static final JodaBeanSer SETTINGS_NO_SHORT = JodaBeanSer.PRETTY.withShortTypes(false);
 
     @Test
-    public void test_encodeType() {
+    void test_encodeType() {
         Map<Class<?>, String> cache = new HashMap<>();
         // base package type
         assertThat(SerTypeMapper.encodeType(BitSet.class, SETTINGS, "java.util.", cache)).isEqualTo("BitSet");
@@ -71,7 +71,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_encodeType_sillyNames() {
+    void test_encodeType_sillyNames() {
         Map<Class<?>, String> cache = new HashMap<>();
         // user type - silly name
         assertThat(SerTypeMapper.encodeType(BigDecimal.class, SETTINGS, "org.joda.beans.ser.", cache)).isEqualTo("org.joda.beans.ser.BigDecimal");
@@ -82,7 +82,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_encodeType_noCache() {
+    void test_encodeType_noCache() {
         // user type
         assertThat(SerTypeMapper.encodeType(AtomicIntegerArray.class, SETTINGS, "java.util.", null))
             .isEqualTo("java.util.concurrent.atomic.AtomicIntegerArray");
@@ -98,7 +98,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_encodeType_noBasePackage() {
+    void test_encodeType_noBasePackage() {
         Map<Class<?>, String> cache = new HashMap<>();
         // basic type
         assertThat(SerTypeMapper.encodeType(File.class, SETTINGS, null, cache)).isEqualTo("File");
@@ -112,7 +112,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_encodeType_noShortTypes() {
+    void test_encodeType_noShortTypes() {
         Map<Class<?>, String> cache = new HashMap<>();
         // base package type
         assertThat(SerTypeMapper.encodeType(BitSet.class, SETTINGS_NO_SHORT, "java.util.", cache)).isEqualTo("java.util.BitSet");
@@ -129,7 +129,7 @@ public class TestSerTypeMapper {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_decodeType() throws Exception {
+    void test_decodeType() throws Exception {
         Map<String, Class<?>> cache = new HashMap<>();
         // base package type
         assertThat(SerTypeMapper.decodeType("BitSet", SETTINGS, "java.util.", cache)).isEqualTo(BitSet.class);
@@ -156,7 +156,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_decodeType_noCache() throws Exception {
+    void test_decodeType_noCache() throws Exception {
         // base package type
         assertThat(SerTypeMapper.decodeType("BitSet", SETTINGS, "java.util.", null)).isEqualTo(BitSet.class);
         // basic type
@@ -166,7 +166,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_decodeType_noBasePackage() throws Exception {
+    void test_decodeType_noBasePackage() throws Exception {
         Map<String, Class<?>> cache = new HashMap<>();
         // basic type
         assertThat(SerTypeMapper.decodeType("File", SETTINGS, null, cache)).isEqualTo(File.class);
@@ -175,7 +175,7 @@ public class TestSerTypeMapper {
     }
 
     @Test
-    public void test_decodeType_emptyClassName() throws Exception {
+    void test_decodeType_emptyClassName() throws Exception {
         Map<String, Class<?>> cache = new HashMap<>();
         assertThatExceptionOfType(ClassNotFoundException.class)
             .isThrownBy(() -> SerTypeMapper.decodeType("", SETTINGS, "java.util.", cache));

--- a/src/test/java/org/joda/beans/ser/TestSerializeSmartReader.java
+++ b/src/test/java/org/joda/beans/ser/TestSerializeSmartReader.java
@@ -39,10 +39,10 @@ import com.google.common.primitives.Bytes;
 /**
  * Test smart reader.
  */
-public class TestSerializeSmartReader {
+class TestSerializeSmartReader {
 
     @Test
-    public void test_binary_address()  throws IOException {
+    void test_binary_address() throws IOException {
         Address bean = SerTestHelper.testAddress();
         byte[] bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -50,7 +50,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_binary_immAddress()  throws IOException {
+    void test_binary_immAddress() throws IOException {
         ImmAddress bean = SerTestHelper.testImmAddress(false);
         byte[] bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -58,7 +58,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_binary_optional()  throws IOException {
+    void test_binary_optional() throws IOException {
         ImmOptional bean = SerTestHelper.testImmOptional();
         byte[] bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -66,7 +66,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_binary_collections()  throws IOException {
+    void test_binary_collections() throws IOException {
         ImmGuava<String> bean = SerTestHelper.testCollections(true);
         byte[] bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -75,7 +75,7 @@ public class TestSerializeSmartReader {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_binaryReferencing_optional()  throws IOException {
+    void test_binaryReferencing_optional() throws IOException {
         ImmOptional bean = SerTestHelper.testImmOptional();
         byte[] bytes = JodaBeanSer.PRETTY.binWriterReferencing().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -83,7 +83,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_binaryReferencing_collections()  throws IOException {
+    void test_binaryReferencing_collections() throws IOException {
         ImmGuava<String> bean = SerTestHelper.testCollections(true);
         byte[] bytes = JodaBeanSer.PRETTY.binWriterReferencing().write(bean);
         Bean roundtrip = JodaBeanSer.PRETTY.smartReader().read(bytes);
@@ -92,63 +92,63 @@ public class TestSerializeSmartReader {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_json_address()  throws IOException {
+    void test_json_address() throws IOException {
         Address bean = SerTestHelper.testAddress();
         String json = JodaBeanSer.PRETTY.jsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, Address.class);
     }
 
     @Test
-    public void test_json_immAddress()  throws IOException {
+    void test_json_immAddress() throws IOException {
         ImmAddress bean = SerTestHelper.testImmAddress(false);
         String json = JodaBeanSer.PRETTY.jsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmAddress.class);
     }
 
     @Test
-    public void test_json_optional()  throws IOException {
+    void test_json_optional() throws IOException {
         ImmOptional bean = SerTestHelper.testImmOptional();
         String json = JodaBeanSer.PRETTY.jsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmOptional.class);
     }
 
     @Test
-    public void test_json_collections()  throws IOException {
+    void test_json_collections() throws IOException {
         ImmGuava<String> bean = SerTestHelper.testCollections(true);
         String json = JodaBeanSer.PRETTY.jsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmGuava.class);
     }
 
     @Test
-    public void test_json_minimal() throws IOException {
+    void test_json_minimal() throws IOException {
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(new byte[] { '{', '}' })).isTrue();
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(new byte[] { '{', '\n', ' ', '}' })).isTrue();
     }
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_simpleJson_empty()  throws IOException {
+    void test_simpleJson_empty() throws IOException {
         ImmEmpty bean = ImmEmpty.builder().build();
         String json = JodaBeanSer.PRETTY.simpleJsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmEmpty.class);
     }
 
     @Test
-    public void test_simpleJson_basic()  throws IOException {
+    void test_simpleJson_basic() throws IOException {
         SimpleJson bean = SerTestHelper.testSimpleJson();
         String json = JodaBeanSer.PRETTY.simpleJsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, SimpleJson.class);
     }
 
     @Test
-    public void test_simpleJson_optional()  throws IOException {
+    void test_simpleJson_optional() throws IOException {
         ImmOptional bean = SerTestHelper.testImmOptional();
         String json = JodaBeanSer.PRETTY.simpleJsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmOptional.class);
     }
 
     @Test
-    public void test_simpleJson_collections()  throws IOException {
+    void test_simpleJson_collections() throws IOException {
         ImmGuava<String> bean = SerTestHelper.testCollections(true);
         String json = JodaBeanSer.PRETTY.simpleJsonWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, json, bean, ImmGuava.class);
@@ -156,35 +156,35 @@ public class TestSerializeSmartReader {
 
     //-----------------------------------------------------------------------
     @Test
-    public void test_xml_address()  throws IOException {
+    void test_xml_address() throws IOException {
         Address bean = SerTestHelper.testAddress();
         String xml = JodaBeanSer.PRETTY.xmlWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, xml, bean, Address.class);
     }
 
     @Test
-    public void test_xml_immAddress()  throws IOException {
+    void test_xml_immAddress() throws IOException {
         ImmAddress bean = SerTestHelper.testImmAddress(false);
         String xml = JodaBeanSer.PRETTY.xmlWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, xml, bean, ImmAddress.class);
     }
 
     @Test
-    public void test_xml_optional()  throws IOException {
+    void test_xml_optional() throws IOException {
         ImmOptional bean = SerTestHelper.testImmOptional();
         String xml = JodaBeanSer.PRETTY.xmlWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, xml, bean, ImmOptional.class);
     }
 
     @Test
-    public void test_xml_collections()  throws IOException {
+    void test_xml_collections() throws IOException {
         ImmGuava<String> bean = SerTestHelper.testCollections(true);
         String xml = JodaBeanSer.PRETTY.xmlWriter().write(bean);
         assertCharsets(JodaBeanSer.PRETTY, xml, bean, ImmGuava.class);
     }
 
     @Test
-    public void test_xml_minimal() throws IOException {
+    void test_xml_minimal() throws IOException {
         byte[] bytes = "<bean></bean>".getBytes(StandardCharsets.UTF_8);
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(bytes)).isTrue();
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(bytes)).isTrue();
@@ -204,7 +204,7 @@ public class TestSerializeSmartReader {
     }
 
     //-----------------------------------------------------------------------
-    public static Object[][] data_badFormat() {
+    static Object[][] data_badFormat() {
         return new Object[][] {
                 { "xml" },
                 { "<beax" },
@@ -219,13 +219,13 @@ public class TestSerializeSmartReader {
 
     @ParameterizedTest
     @MethodSource("data_badFormat")
-    public void test_badFormat(String text) throws IOException {
+    void test_badFormat(String text) throws IOException {
         byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
         assertThatIllegalArgumentException()
             .isThrownBy(() -> JodaBeanSer.COMPACT.smartReader().read(bytes, FlexiBean.class));
     }
 
-    public static Object[][] data_unknownFormat() {
+    static Object[][] data_unknownFormat() {
         return new Object[][] {
                 { "xml" },
                 { "<beax" },
@@ -238,13 +238,13 @@ public class TestSerializeSmartReader {
 
     @ParameterizedTest
     @MethodSource("data_unknownFormat")
-    public void test_isKnownFormat_false(String text) throws IOException {
+    void test_isKnownFormat_false(String text) throws IOException {
         byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(bytes)).isFalse();
     }
 
     @Test
-    public void test_isKnownFormat_utf8_wrong() throws IOException {
+    void test_isKnownFormat_utf8_wrong() throws IOException {
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
                 new byte[] { (byte) 0xef, (byte) 0xbb, (byte) 0xbf, '?' })).isFalse();
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
@@ -256,7 +256,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_isKnownFormat_utf16le_wrong() throws IOException {
+    void test_isKnownFormat_utf16le_wrong() throws IOException {
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
                 new byte[] { (byte) 0xff, (byte) 0xfe, '?', (byte) 0x00 })).isFalse();
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
@@ -268,7 +268,7 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_isKnownFormat_utf16be_wrong() throws IOException {
+    void test_isKnownFormat_utf16be_wrong() throws IOException {
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
                 new byte[] { (byte) 0xfe, (byte) 0xff, (byte) 0x00, '?' })).isFalse();
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(
@@ -280,13 +280,13 @@ public class TestSerializeSmartReader {
     }
 
     @Test
-    public void test_isKnownFormat_binary_false() throws IOException {
+    void test_isKnownFormat_binary_false() throws IOException {
         byte[] bytes = new byte[] {(byte) 0x92, (byte) 0x00};
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(bytes)).isFalse();
     }
 
     @Test
-    public void test_isKnownFormat_binaryRef_false() throws IOException {
+    void test_isKnownFormat_binaryRef_false() throws IOException {
         byte[] bytes = new byte[] {(byte) 0x94, (byte) 0x00};
         assertThat(JodaBeanSer.COMPACT.smartReader().isKnownFormat(bytes)).isFalse();
     }

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializeReferencingBin.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 import static org.assertj.core.api.Assertions.offset;
+import static org.joda.beans.ser.bin.JodaBeanBinFormat.REFERENCING;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -60,7 +61,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_writeImmAddress() throws IOException {
         var bean = SerTestHelper.testImmAddress(true);
-        var bytes = JodaBeanSer.PRETTY.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmAddress1.refbinstr");
 
@@ -72,7 +73,7 @@ public class TestSerializeReferencingBin {
     public void test_writeImmOptional() throws IOException {
         // derived properties are not supported
         var bean = SerTestHelper.testImmOptional();
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmOptional1.refbinstr");
 
@@ -89,7 +90,7 @@ public class TestSerializeReferencingBin {
                 new boolean[] {true, false},
                 new int[][] {{1, 2}, {2}, {}},
                 new boolean[][] {{true, false}, {false}, {}});
-        var bytes = JodaBeanSer.PRETTY.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmArrays1.refbinstr");
 
@@ -100,7 +101,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_writeCollections() throws IOException {
         var bean = SerTestHelper.testCollections(true);
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/Collections1.refbinstr");
 
@@ -121,7 +122,7 @@ public class TestSerializeReferencingBin {
     public void test_writeJodaConvertInterface() {
         var bean = SerTestHelper.testGenericInterfaces();
 
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         @SuppressWarnings("unchecked")
@@ -133,7 +134,7 @@ public class TestSerializeReferencingBin {
     public void test_writeIntermediateInterface() {
         var bean = SerTestHelper.testIntermediateInterfaces();
 
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmKeyList.class);
@@ -145,7 +146,7 @@ public class TestSerializeReferencingBin {
         // immutable bean that is serialized as joda convert
         var bean = ImmNamedKey.of("name");
 
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         var parsed = (ImmNamedKey) JodaBeanSer.COMPACT.binReader().read(bytes);
@@ -155,7 +156,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_writeGenericCollections() {
         var bean = SerTestHelper.testGenericNestedCollections();
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         @SuppressWarnings("unchecked")
@@ -166,7 +167,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_writeFirstInstanceOfBeanHasNullProperties() {
         var bean = SerTestHelper.testGenericArrayWithNulls();
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         @SuppressWarnings("unchecked")
@@ -177,7 +178,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_writeTree() {
         var bean = SerTestHelper.testTree();
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
         var regularBytes = JodaBeanSer.COMPACT.binWriter().write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
@@ -190,7 +191,7 @@ public class TestSerializeReferencingBin {
     @Test
     public void test_read_deserializerReferencesUnseenClass() {
         var immKeyHolder = SerTestHelper.testImmKeyHolder();
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(immKeyHolder);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(immKeyHolder);
         var bean = (ImmKeyHolder) JodaBeanSer.COMPACT.binReader().read(bytes);
         BeanAssert.assertBeanEquals(bean, immKeyHolder);
     }
@@ -319,7 +320,7 @@ public class TestSerializeReferencingBin {
 
         var bean = new ImmJodaConvertBean("Hello:9");
         var wrapper = ImmJodaConvertWrapper.of(bean, "Weird");
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(wrapper);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(wrapper);
         assertThat(bytes).isEqualTo(expected);
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmJodaConvertWrapper.class);
         BeanAssert.assertBeanEquals(wrapper, parsed);
@@ -353,7 +354,7 @@ public class TestSerializeReferencingBin {
         var expected = baos.toByteArray();
 
         var bean = new ImmJodaConvertBean("Hello:9");
-        var bytes = JodaBeanSer.COMPACT.binWriterReferencing().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(REFERENCING).write(bean);
 
         assertThat(bytes).isEqualTo(expected);
 

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializeStandardBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializeStandardBin.java
@@ -19,6 +19,7 @@ import static java.lang.System.lineSeparator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 import static org.assertj.core.api.Assertions.offset;
+import static org.joda.beans.ser.bin.JodaBeanBinFormat.STANDARD;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -58,7 +59,7 @@ public class TestSerializeStandardBin {
     public void test_writeAddress() throws IOException {
         var bean = SerTestHelper.testAddress();
 
-        var bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/Address2.binstr");
 
@@ -69,7 +70,7 @@ public class TestSerializeStandardBin {
     @Test
     public void test_writeImmAddress() throws IOException {
         var bean = SerTestHelper.testImmAddress(false);
-        var bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmAddress2.binstr");
 
@@ -82,7 +83,7 @@ public class TestSerializeStandardBin {
     @Test
     public void test_writeImmOptional() throws IOException {
         var bean = SerTestHelper.testImmOptional();
-        var bytes = JodaBeanSer.PRETTY.withIncludeDerived(true).binWriter().write(bean);
+        var bytes = JodaBeanSer.PRETTY.withIncludeDerived(true).binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmOptional2.binstr");
 
@@ -99,7 +100,7 @@ public class TestSerializeStandardBin {
                 new boolean[] {true, false},
                 new int[][] {{1, 2}, {2}, {}},
                 new boolean[][] {{true, false}, {false}, {}});
-        var bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmArrays2.binstr");
 
@@ -112,7 +113,7 @@ public class TestSerializeStandardBin {
     @Test
     public void test_writeCollections() throws IOException {
         var bean = SerTestHelper.testCollections(true);
-        var bytes = JodaBeanSer.PRETTY.binWriter().write(bean);
+        var bytes = JodaBeanSer.PRETTY.binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
         assertEqualsSerialization(bytes, "/org/joda/beans/ser/Collections2.binstr");
 
@@ -135,7 +136,7 @@ public class TestSerializeStandardBin {
     public void test_writeJodaConvertInterface() {
         var bean = SerTestHelper.testGenericInterfaces();
 
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean);
 //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes);
@@ -146,7 +147,7 @@ public class TestSerializeStandardBin {
     public void test_writeIntermediateInterface() {
         var bean = SerTestHelper.testIntermediateInterfaces();
 
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean);
         //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmKeyList.class);
@@ -158,7 +159,7 @@ public class TestSerializeStandardBin {
         // immutable bean that is serialized as joda convert
         var bean = ImmNamedKey.of("name");
 
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(bean);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean);
         //        System.out.println(JodaBeanBinReader.visualize(bytes));
 
         var parsed = (ImmNamedKey) JodaBeanSer.COMPACT.binReader().read(bytes);
@@ -213,7 +214,7 @@ public class TestSerializeStandardBin {
         bean.set("sht", Short.valueOf((short) 2));
         bean.set("flt", Float.valueOf(1.2f));
         bean.set("dbl", Double.valueOf(1.8d));
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(bean, false);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean, false);
         assertThat(bytes).isEqualTo(expected);
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
         BeanAssert.assertBeanEquals(bean, parsed);
@@ -275,7 +276,7 @@ public class TestSerializeStandardBin {
         var bean = new JodaConvertBean("Hello:9");
         wrapper.setBean(bean);
         wrapper.setDescription("Weird");
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(wrapper, false);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(wrapper, false);
         assertThat(bytes).isEqualTo(expected);
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertWrapper.class);
         BeanAssert.assertBeanEquals(wrapper, parsed);
@@ -299,7 +300,7 @@ public class TestSerializeStandardBin {
         var expected = baos.toByteArray();
 
         var bean = new JodaConvertBean("Hello:9");
-        var bytes = JodaBeanSer.COMPACT.binWriter().write(bean, false);
+        var bytes = JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean, false);
         assertThat(bytes).isEqualTo(expected);
         var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertBean.class);
         BeanAssert.assertBeanEquals(bean, parsed);
@@ -578,7 +579,7 @@ public class TestSerializeStandardBin {
         var bean = new Person();
         bean.getOtherAddressMap().put(null, address);
         assertThatRuntimeException()
-                .isThrownBy(() -> JodaBeanSer.COMPACT.binWriter().write(bean));
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binWriter(STANDARD).write(bean));
     }
 
 }


### PR DESCRIPTION
* Replace boolean flag with enum
* Easier to support more format versions
* Enhance test cases
* Move `ImmutableBean` check into referencing class
* Fix stray catch of `UncheckedIOException`
* Convert some tests to package scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced binary format handling capabilities with two formats: `STANDARD` and `REFERENCING`.
	- Added methods for explicit control over binary serialization formats.

- **Bug Fixes**
	- Enhanced type safety in the `write` method of `JodaBeanReferencingBinWriter`.

- **Documentation**
	- Updated method documentation for clarity and accuracy regarding functionality.

- **Tests**
	- Added a new test class to verify the version numbers of binary formats.
	- Standardised binary serialization tests to use specific formats. 

- **Chores**
	- Refactored method signatures for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->