### PR TITLE
Create packed binary format

### DIFF
--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
@@ -15,6 +15,8 @@
  */
 package org.joda.beans.ser.bin;
 
+import org.joda.beans.ser.JodaBeanSer;
+
 /**
  * Provides control over the binary format.
  * 
@@ -85,7 +87,17 @@ public enum JodaBeanBinFormat {
      * and the object that should be referred to as the value.
      * When that same object is referred back to it is written as 'ext' with the data from the initial 'ext'.
      */
-    REFERENCING(2);
+    REFERENCING(2),
+    /**
+     * Packed format, version 3
+     * <p>
+     * This format uses a structure called BeanPack that is similar to MessagePack, but distinctly different.
+     * The exact format is not specified and may change over time.
+     * Types, bean definitions and string values are captured the first time they are found and then used by reference.
+     * In addition, {@link JodaBeanSer#getBeanValueClasses()} is taken into account, with instances of the specified
+     * value classes being deduplicated in the binary form.
+     */
+    PACKED(3);
 
     /**
      * The format version.

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinReader.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinReader.java
@@ -45,6 +45,9 @@ public class JodaBeanBinReader extends MsgPack {
      * @return the visualization
      */
     public static String visualize(byte[] input) {
+        if (input.length >= 2 && input[1] == 3) {
+            return new BeanPackVisualizer(input).visualizeData();
+        }
         return new MsgPackVisualizer(input).visualizeData();
     }
 
@@ -138,9 +141,15 @@ public class JodaBeanBinReader extends MsgPack {
                             "Invalid binary data: Expected array with 4 elements, but was: 0x" + toHex(arrayByte));
                 }
                 return new JodaBeanReferencingBinReader(settings, input).read(declaredType);
+            case 3:
+                if (arrayByte != MIN_FIX_ARRAY + 3) {
+                    throw new IllegalArgumentException(
+                            "Invalid binary data: Expected array with 3 elements, but was: 0x" + toHex(arrayByte));
+                }
+                return new JodaBeanPackedBinReader(settings, input).read(declaredType);
             default:
                 throw new IllegalArgumentException(
-                        "Invalid binary data: Expected version 1 or 2, but was: 0x" + toHex(versionByte));
+                        "Invalid binary data: Expected version 1, 2 or 3, but was: 0x" + toHex(versionByte));
         }
     }
 

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinWriter.java
@@ -136,7 +136,8 @@ public class JodaBeanBinWriter {
         switch (format) {
             case STANDARD -> new JodaBeanStandardBinWriter(settings, output).write(bean, includeRootType);
             case REFERENCING -> new JodaBeanReferencingBinWriter(settings, output).write(bean);
-            default -> throw new IllegalArgumentException("Invalid bin format, must be 1 or 2");
+            case PACKED -> new JodaBeanPackedBinWriter(settings, output).write(bean, includeRootType);
+            default -> throw new IllegalArgumentException("Invalid bin format, must be Standard, Referencing or Packed");
         }
     }
 

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinReader.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinReader.java
@@ -1,0 +1,1084 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser.bin;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.joda.beans.Bean;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.ResolvedType;
+import org.joda.beans.ser.JodaBeanSer;
+import org.joda.beans.ser.SerTypeMapper;
+import org.joda.collect.grid.DenseGrid;
+import org.joda.collect.grid.Grid;
+import org.joda.collect.grid.ImmutableGrid;
+import org.joda.collect.grid.SparseGrid;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeMultiset;
+
+/**
+ * Reads the Joda-Bean BeanPack binary format with strings deduplicated by reference.
+ * <p>
+ * This class contains mutable state and cannot be used from multiple threads.
+ * A new instance must be created for each message.
+ */
+final class JodaBeanPackedBinReader extends BeanPack {
+
+    /**
+     * The resolved type for {@code Map<Object, Object>}.
+     */
+    private static final ResolvedType MAP_TYPE = ResolvedType.ofFlat(Map.class, Object.class, Object.class);
+    /**
+     * The resolved type for {@code List<Object>}.
+     */
+    private static final ResolvedType LIST_TYPE = ResolvedType.ofFlat(List.class, Object.class);
+
+    // why is there an ugly ClassValue setup here?
+    // because this is O(1) whereas switch with pattern match which is O(n)
+    private static final ClassValue<BinHandler> LOOKUP = new ClassValue<>() {
+
+        @SuppressWarnings("rawtypes")  // sneaky use of raw type to allow typed value in each method below
+        @Override
+        protected BinHandler computeValue(Class<?> type) {
+            return BaseBinHandlers.INSTANCE.createHandler(type);
+        }
+    };
+    /**
+     * Map of array types.
+     */
+    private static final Map<String, Class<?>> ARRAY_TYPE_NAME_MAP = new HashMap<>();
+    static {
+        ARRAY_TYPE_NAME_MAP.put("Object[]", Object[].class);
+        ARRAY_TYPE_NAME_MAP.put("String[]", String[].class);
+        ARRAY_TYPE_NAME_MAP.put("boolean[]", boolean[].class);
+        ARRAY_TYPE_NAME_MAP.put("char[]", char[].class);
+        ARRAY_TYPE_NAME_MAP.put("byte[]", byte[].class);
+        ARRAY_TYPE_NAME_MAP.put("short[]", short[].class);
+        ARRAY_TYPE_NAME_MAP.put("int[]", int[].class);
+        ARRAY_TYPE_NAME_MAP.put("long[]", long[].class);
+        ARRAY_TYPE_NAME_MAP.put("float[]", float[].class);
+        ARRAY_TYPE_NAME_MAP.put("double[]", double[].class);
+    }
+
+    /**
+     * Settings.
+     */
+    final JodaBeanSer settings;  // CSIGNORE
+    /**
+     * The reader.
+     */
+    final DataInputStream input;  // CSIGNORE
+    /**
+     * The base package including the trailing dot.
+     */
+    private String basePackage;
+    /**
+     * The known types.
+     */
+    private final Map<String, Class<?>> knownTypes = new HashMap<>();
+    /**
+     * The type definitions.
+     */
+    private final List<ResolvedType> typeDefinitions = new ArrayList<>();
+    /**
+     * The bean definitions.
+     */
+    private final Map<Class<?>, List<MetaProperty<?>>> beanDefinitions = new IdentityHashMap<>();
+    /**
+     * The value definitions.
+     */
+    private final List<Object> valueDefinitions = new ArrayList<>();
+
+    //-----------------------------------------------------------------------
+    // creates an instance
+    JodaBeanPackedBinReader(JodaBeanSer settings, DataInputStream input) {
+        this.settings = settings;
+        this.input = input;
+    }
+
+    //-----------------------------------------------------------------------
+    // reads the input stream where the array and version bytes have been read already
+    <T> T read(Class<T> rootType) {
+        try {
+            try {
+                return parseRemaining(rootType);
+            } finally {
+                input.close();
+            }
+        } catch (RuntimeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    <T> T parseRemaining(Class<T> declaredType) throws Exception {
+        // the array and version has already been read
+        basePackage = acceptStringOrNull();
+        var parsed = parseObject(ResolvedType.from(declaredType));
+        return declaredType.cast(parsed);
+    }
+
+    //-------------------------------------------------------------------------
+    // parses an object, determining how to parse based on the input data
+    Object parseObject(ResolvedType declaredType) throws IOException {
+        var typeByte = input.readByte();
+
+        // parse the type code
+        return switch (typeByte) {
+            case MIN_FIX_MAP -> parseMap(0, declaredType);
+            case MIN_FIX_MAP + 1 -> parseMap(1, declaredType);
+            case MIN_FIX_MAP + 2 -> parseMap(2, declaredType);
+            case MIN_FIX_MAP + 3 -> parseMap(3, declaredType);
+            case MIN_FIX_MAP + 4 -> parseMap(4, declaredType);
+            case MIN_FIX_MAP + 5 -> parseMap(5, declaredType);
+            case MIN_FIX_MAP + 6 -> parseMap(6, declaredType);
+            case MIN_FIX_MAP + 7 -> parseMap(7, declaredType);
+            case MIN_FIX_MAP + 8 -> parseMap(8, declaredType);
+            case MIN_FIX_MAP + 9 -> parseMap(9, declaredType);
+            case MIN_FIX_MAP + 10 -> parseMap(10, declaredType);
+            case MIN_FIX_MAP + 11 -> parseMap(11, declaredType);
+            case MIN_FIX_MAP + 12 -> parseMap(12, declaredType);
+            case MAP_8 -> parseMap(input.readUnsignedByte(), declaredType);
+            case MAP_16 -> parseMap(input.readUnsignedShort(), declaredType);
+            case MAP_32 -> parseMap(input.readInt(), declaredType);
+            case MIN_FIX_ARRAY -> parseArray(0, declaredType);
+            case MIN_FIX_ARRAY + 1 -> parseArray(1, declaredType);
+            case MIN_FIX_ARRAY + 2 -> parseArray(2, declaredType);
+            case MIN_FIX_ARRAY + 3 -> parseArray(3, declaredType);
+            case MIN_FIX_ARRAY + 4 -> parseArray(4, declaredType);
+            case MIN_FIX_ARRAY + 5 -> parseArray(5, declaredType);
+            case MIN_FIX_ARRAY + 6 -> parseArray(6, declaredType);
+            case MIN_FIX_ARRAY + 7 -> parseArray(7, declaredType);
+            case MIN_FIX_ARRAY + 8 -> parseArray(8, declaredType);
+            case MIN_FIX_ARRAY + 9 -> parseArray(9, declaredType);
+            case MIN_FIX_ARRAY + 10 -> parseArray(10, declaredType);
+            case MIN_FIX_ARRAY + 11 -> parseArray(11, declaredType);
+            case MIN_FIX_ARRAY + 12 -> parseArray(12, declaredType);
+            case ARRAY_8 -> parseArray(input.readUnsignedByte(), declaredType);
+            case ARRAY_16 -> parseArray(input.readUnsignedShort(), declaredType);
+            case ARRAY_32 -> parseArray(input.readInt(), declaredType);
+            case STR_8 -> parseString(input.readUnsignedByte(), declaredType);
+            case STR_16 -> parseString(input.readUnsignedShort(), declaredType);
+            case STR_32 -> parseString(input.readInt(), declaredType);
+            case NULL -> null;
+            case FALSE -> false;
+            case TRUE -> true;
+            case UNUSED -> parseUnknown();
+            case FLOAT_32 -> input.readFloat();
+            case DOUBLE_INT_8 -> (double) input.readByte();
+            case DOUBLE_64 -> input.readDouble();
+            case CHAR_16 -> input.readChar();
+            case BYTE_8 -> parseByte(input.readByte(), declaredType);
+            case SHORT_16 -> parseShort(input.readShort(), declaredType);
+            case INT_16 -> parseInt(input.readShort(), declaredType);
+            case INT_32 -> parseInt(input.readInt(), declaredType);
+            case LONG_8 -> parseLong(input.readByte(), declaredType);
+            case LONG_16 -> parseLong(input.readShort(), declaredType);
+            case LONG_32 -> parseLong(input.readInt(), declaredType);
+            case LONG_64 -> parseLong(input.readLong(), declaredType);
+            case DATE_PACKED -> parseDatePacked();
+            case DATE -> parseDate();
+            case TIME -> parseTime();
+            case INSTANT -> parseInstant();
+            case DURATION -> parseDuration();
+            case BIN_8 -> parseByteArray(input.readUnsignedByte());
+            case BIN_16 -> parseByteArray(input.readUnsignedShort());
+            case BIN_32 -> parseByteArray(input.readInt());
+            case DOUBLE_ARRAY_8 -> parseDoubleArray(input.readUnsignedByte());
+            case DOUBLE_ARRAY_16 -> parseDoubleArray(input.readUnsignedShort());
+            case DOUBLE_ARRAY_32 -> parseDoubleArray(input.readInt());
+            case TYPE_DEFN_8 -> parseTypeDefinition(input.readUnsignedByte());
+            case TYPE_DEFN_16 -> parseTypeDefinition(input.readUnsignedShort());
+            case TYPE_REF_8 -> parseTypeRef(input.readByte(), declaredType);
+            case TYPE_REF_16 -> parseTypeRef(input.readUnsignedShort(), declaredType);
+            case BEAN_DEFN -> parseBeanDefinition(input.readUnsignedByte(), declaredType);
+            case VALUE_DEFN -> parseValueDefinition(declaredType);
+            case VALUE_REF_8 -> parseValueRef(input.readUnsignedByte(), declaredType);
+            case VALUE_REF_16 -> parseValueRef(input.readUnsignedShort(), declaredType);
+            case VALUE_REF_24 -> parseValueRef((input.readUnsignedByte() << 16) + input.readUnsignedShort(), declaredType);
+            default -> typeByte < MIN_FIX_INT ?
+                    parseString(typeByte - MIN_FIX_STR, declaredType) :
+                    parseInt(typeByte, declaredType);
+        };
+    }
+
+    //-------------------------------------------------------------------------
+    // parse a BeanPack map
+    private Object parseMap(int size, ResolvedType declaredType) throws IOException {
+        var rawType = declaredType.getRawType();
+        if (Bean.class.isAssignableFrom(rawType)) {
+            return parseMapAsBean(size, rawType, false);
+        } else {
+            return parseViaHandler(size, rawType == Object.class ? MAP_TYPE : declaredType);
+        }
+    }
+
+    // parse a BeanPack array
+    private Object parseArray(int size, ResolvedType declaredType) throws IOException {
+        var rawType = declaredType.getRawType();
+        if (Bean.class.isAssignableFrom(rawType)) {
+            return parseArrayAsBean(size, rawType);
+        } else {
+            return parseViaHandler(size, rawType == Object.class ? LIST_TYPE : declaredType);
+        }
+    }
+
+    // parse a BeanPack map as a Map/Array
+    private Object parseViaHandler(int size, ResolvedType declaredType) throws IOException {
+        var handler = LOOKUP.get(declaredType.getRawType());
+        return handler.handle(this, declaredType, size);
+    }
+
+    //-------------------------------------------------------------------------
+    // parse a BeanPack string
+    private Object parseString(int strLen, ResolvedType declaredType) throws IOException {
+        var str = acceptStringBytes(strLen);
+        return interpretString(str, declaredType);
+    }
+
+    private Object interpretString(String str, ResolvedType declaredType) {
+        if (declaredType.getRawType().isAssignableFrom(String.class)) {
+            return str;
+        } else {
+            // Joda-Convert
+            return settings.getConverter().convertFromString(declaredType.getRawType(), str);
+        }
+    }
+
+    private Object parseUnknown() {
+        throw new IllegalArgumentException("Invalid binary data: Unknown type byte");
+    }
+
+    //-------------------------------------------------------------------------
+    // parse the type name, validate it, store it in the type cache and parse the actual value
+    private Object parseTypeDefinition(int size) throws IOException {
+        // manually parse, as separate from the value definition
+        var bytes = new byte[size];
+        input.readFully(bytes);
+        var typeName = new String(bytes, UTF_8);
+        // interpret the type, which is always a Class (not a ResolvedType)
+        Class<?> decodedType = decodeTypeName(typeName);
+        var effectiveType = ResolvedType.of(decodedType);
+        typeDefinitions.add(effectiveType);
+        return parseObject(effectiveType);
+    }
+
+    private Class<?> decodeTypeName(String typeName) {
+        try {
+            if (typeName.endsWith("[]")) {
+                return decodeArrayTypeName(typeName);
+            } else {
+                return settings.getDeserializers().decodeType(typeName, settings, basePackage, knownTypes, Object.class);
+            }
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    // finds the array type from a string like int[] or Foo[][]
+    private Class<?> decodeArrayTypeName(String typeName) throws ClassNotFoundException {
+        var type = ARRAY_TYPE_NAME_MAP.get(typeName);
+        if (type != null) {
+            return type;
+        }
+        var clsStr = typeName.substring(0, typeName.length() - 2);
+        if (clsStr.endsWith("[]")) {
+            return decodeArrayTypeName(clsStr).arrayType();
+        }
+        return SerTypeMapper.decodeType(clsStr, settings, null, knownTypes).arrayType();
+    }
+
+    // parse the int reference, negative for type codes and positive for user types
+    private Object parseTypeRef(int ref, ResolvedType declaredType) throws IOException {
+        if (ref < 0) {
+            var rawEffectiveType = BaseBinHandlers.INSTANCE.classForTypeCode(ref);
+            var effectiveType = ResolvedType.of(rawEffectiveType);
+            return parseObject(effectiveType);
+        } else {
+            var effectiveType = typeDefinitions.get(ref);
+            return parseObject(effectiveType);
+        }
+    }
+
+    // parse the actual bean, passing down a flag so that the meta-properties are stored in the bean cache
+    private Object parseBeanDefinition(int propertyCount, ResolvedType declaredType) throws IOException {
+        // when written, the bean definition is always preceded by a type definition/ref
+        var beanType = declaredType.getRawType();
+        if (!Bean.class.isAssignableFrom(beanType)) {
+            throw new IllegalArgumentException("Invalid binary data: Expected bean, but found " + declaredType);
+        }
+        // parse the meta-property names first
+        var deser = settings.getDeserializers().findDeserializer(beanType);
+        var metaBean = deser.findMetaBean(beanType);
+        var metaProperties = new ArrayList<MetaProperty<?>>(propertyCount);
+        for (var i = 0; i < propertyCount; i++) {
+            var propName = acceptString();
+            var metaProp = deser.findMetaProperty(beanType, metaBean, propName);
+            if (metaProp == null || !settings.isSerialized(metaProp)) {
+                metaProperties.add(null);  // message contains a property that is no longer in the bean
+            } else {
+                metaProperties.add(metaProp);
+            }
+        }
+        beanDefinitions.put(beanType, metaProperties);
+        // now the meta-property names are stored, we can parse the bean values
+        var propName = "";
+        try {
+            var builder = deser.createBuilder(beanType, metaBean);
+            for (var i = 0; i < propertyCount; i++) {
+                var metaProp = metaProperties.get(i);
+                if (metaProp == null) {
+                    propName = "<skipped>";
+                    skipObject();
+                } else {
+                    propName = metaProp.name();
+                    var value = parseObject(metaProp.propertyResolvedType(beanType));
+                    deser.setValue(builder, metaProp, value);
+                }
+            }
+            propName = "<init>";
+            return deser.build(beanType, builder);
+        } catch (IOException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw invalidBean(beanType, propName, ex);
+        }
+    }
+
+    // parse the actual value, store it in the value cache, and return the value
+    private Object parseValueDefinition(ResolvedType declaredType) throws IOException {
+        var obj = parseObject(declaredType);
+        valueDefinitions.add(obj);
+        return obj;
+    }
+
+    // obtain the value reference, query the value cache, and return the value
+    private Object parseValueRef(int ref, ResolvedType declaredType) throws IOException {
+        var value = valueDefinitions.get(ref);
+        if (value instanceof String str) {
+            return interpretString(str, declaredType);
+        } else if (value != null) {
+            return value;
+        } else {
+            throw new IllegalArgumentException("Invalid binary data: Referenced value not found: ref " + ref);
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // parse a BeanPack map that has been identified as a bean
+    private Object parseMapAsBean(int mapSize, Class<?> beanType, boolean isDefinition) throws IOException {
+        var propName = "";
+        try {
+            var deser = settings.getDeserializers().findDeserializer(beanType);
+            var metaBean = deser.findMetaBean(beanType);
+            var builder = deser.createBuilder(beanType, metaBean);
+            var metaProperties = new ArrayList<MetaProperty<?>>(mapSize);
+            for (var i = 0; i < mapSize; i++) {
+                propName = acceptString();
+                var metaProp = deser.findMetaProperty(beanType, metaBean, propName);
+                if (metaProp == null || metaProp.style().isDerived()) {
+                    skipObject();
+                    metaProperties.add(null);
+                } else {
+                    var value = parseObject(metaProp.propertyResolvedType(beanType));
+                    deser.setValue(builder, metaProp, value);
+                    metaProperties.add(metaProp);
+                }
+            }
+            if (isDefinition) {
+                beanDefinitions.put(beanType, metaProperties);
+            }
+            propName = "<init>";
+            return deser.build(beanType, builder);
+        } catch (IOException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw invalidBean(beanType, propName, ex);
+        }
+    }
+
+    // parse a BeanPack array that has been identified as a bean (by reference)
+    private Object parseArrayAsBean(int arraySize, Class<?> beanType) throws IOException {
+        var propName = "";
+        try {
+            var deser = settings.getDeserializers().findDeserializer(beanType);
+            var metaBean = deser.findMetaBean(beanType);
+            var builder = deser.createBuilder(beanType, metaBean);
+            var metaProperties = beanDefinitions.get(beanType);
+            if (metaProperties == null) {
+                throw invalidBeanRef(beanType);
+            }
+            if (metaProperties.size() != arraySize) {
+                throw invalidBeanRefSize(beanType);
+            }
+            for (var i = 0; i < arraySize; i++) {
+                var metaProp = metaProperties.get(i);
+                if (metaProp == null) {
+                    propName = "<skipped>";
+                    skipObject();
+                } else {
+                    propName = metaProp.name();
+                    var value = parseObject(metaProp.propertyResolvedType(beanType));
+                    deser.setValue(builder, metaProp, value);
+                }
+            }
+            propName = "<init>";
+            return deser.build(beanType, builder);
+        } catch (IOException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw invalidBean(beanType, propName, ex);
+        }
+    }
+
+    private IllegalArgumentException invalidBeanRef(Class<?> beanType) {
+        return new IllegalArgumentException(
+                "Invalid binary data: Referenced bean not found: " + beanType.getName());
+    }
+
+    private IllegalArgumentException invalidBeanRefSize(Class<?> beanType) {
+        return new IllegalArgumentException(
+                "Invalid binary data: Referenced bean had different number of properties: " + beanType.getName());
+    }
+
+    private RuntimeException invalidBean(Class<?> beanType, String propName, Exception ex) {
+        return new RuntimeException("Error parsing bean: " + beanType.getName() + "::" + propName + ", " + ex.getMessage(), ex);
+    }
+
+    //-------------------------------------------------------------------------
+    // parse a byte, allowing conversion to other number types
+    private Object parseByte(byte value, ResolvedType declaredType) {
+        var desiredType = declaredType.getRawType();
+        if (desiredType == byte.class || desiredType == Byte.class) {
+            return value;
+        } else {
+            return parseLongWithConversion(value, value, desiredType);
+        }
+    }
+
+    // parse a short, allowing conversion to other number types
+    private Object parseShort(short value, ResolvedType declaredType) {
+        var desiredType = declaredType.getRawType();
+        if (desiredType == short.class || desiredType == Short.class) {
+            return value;
+        } else {
+            return parseLongWithConversion(value, value, desiredType);
+        }
+    }
+
+    // parse an int, allowing conversion to other number types
+    private Object parseInt(int value, ResolvedType declaredType) {
+        var desiredType = declaredType.getRawType();
+        if (desiredType == int.class || desiredType == Integer.class) {
+            return value;
+        } else {
+            return parseLongWithConversion(value, value, desiredType);
+        }
+    }
+
+    // parse a long, allowing conversion to other number types
+    private Object parseLong(long value, ResolvedType declaredType) {
+        var desiredType = declaredType.getRawType();
+        if (desiredType == long.class || desiredType == Long.class) {
+            return value;
+        } else {
+            return parseLongWithConversion(value, value, desiredType);
+        }
+    }
+
+    // convert the value that we have been given to the desired type
+    private Object parseLongWithConversion(long value, Number defaultValue, Class<?> desiredType) {
+        if (desiredType == Object.class || desiredType == Number.class) {
+            return defaultValue;
+        } else if (desiredType == Long.class || desiredType == long.class) {
+            return value;
+        } else if (desiredType == Integer.class || desiredType == int.class) {
+            if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("Invalid binary data: Expected int, but was " + value);
+            }
+            return Integer.valueOf((int) value);
+        } else if (desiredType == Double.class || desiredType == double.class) {
+            return Double.valueOf(value);
+        } else if (desiredType == Float.class || desiredType == float.class) {
+            return Float.valueOf(value);
+        } else if (desiredType == Short.class || desiredType == short.class) {
+            if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+                throw new IllegalArgumentException("Invalid binary data: Expected short, but was " + value);
+            }
+            return Short.valueOf((short) value);
+        } else if (desiredType == Byte.class || desiredType == byte.class) {
+            if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                throw new IllegalArgumentException("Invalid binary data: Expected byte, but was " + value);
+            }
+            return Byte.valueOf((byte) value);
+        }
+        return defaultValue;  // will probably throw an exception in the calling code
+    }
+
+    //-------------------------------------------------------------------------
+    private LocalDate parseDatePacked() throws IOException {
+        var packed = input.readUnsignedShort();
+        var dom = packed & 31;
+        var ym = packed >> 5;
+        return LocalDate.of((ym / 12) + 2000, (ym % 12) + 1, dom);
+    }
+
+    private LocalDate parseDate() throws IOException {
+        var upper = input.readInt();
+        var lower = input.readUnsignedByte();
+        var year = upper >> 1;
+        var month = ((upper & 1) << 3) + (lower >>> 5);
+        var dom = lower & 31;
+        return LocalDate.of(year, month, dom);
+    }
+
+    private LocalTime parseTime() throws IOException {
+        var upper = input.readShort();
+        var lower = Integer.toUnsignedLong(input.readInt());
+        var nod = ((long) upper << 32) + lower;
+        return LocalTime.ofNanoOfDay(nod);
+    }
+
+    private Instant parseInstant() throws IOException {
+        var second = input.readLong();
+        var nanos = input.readInt();
+        return Instant.ofEpochSecond(second, nanos);
+    }
+
+    private Duration parseDuration() throws IOException {
+        var seconds = input.readLong();
+        var nanos = input.readInt();
+        return Duration.ofSeconds(seconds, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    private byte[] parseByteArray(int size) throws IOException {
+        var bytes = new byte[size];
+        input.readFully(bytes);
+        return bytes;
+    }
+
+    private double[] parseDoubleArray(int size) throws IOException {
+        var values = new double[size];
+        for (int i = 0; i < size; i++) {
+            values[i] = input.readDouble();
+        }
+        return values;
+    }
+
+    //-------------------------------------------------------------------------
+    private void skipObject() throws IOException {
+        // The only things we care about here are type definitions, bean definition and value definitions.
+        // Type definitions contain the class name, allowing normal parsing to resume.
+        // Bean definitions are always written preceded by a class name, which is sufficient to read the definition.
+        // Value definitions are always written preceded by a class name, which is sufficient to read the definition.
+        //
+        // Each bean acts as a point of separation, where the resolved type is deliberately dropped.
+        // As such, a meta-property holding a generic bean will only use the raw form of the bean for typing.
+        //
+        // A collection is held either in a property, in which case the type is obtained via the property
+        // or it is held in Object/Serializable, in which case no type information is available.
+        // No collection-like class has a generified superclass that is not handled, thus there are no gaps in the type knowledge.
+        parseObject(ResolvedType.OBJECT);
+    }
+
+    private String acceptString() throws IOException {
+        return acceptString(input.readByte());
+    }
+
+    private String acceptStringOrNull() throws IOException {
+        var typeByte = input.readByte();
+        return typeByte == NULL ? null : acceptString(typeByte);
+    }
+
+    private String acceptString(int typeByte) throws IOException {
+        int size;
+        if (typeByte == VALUE_REF_8) {
+            return parseValueRef(input.readUnsignedByte(), ResolvedType.STRING).toString();
+        } else if (typeByte == VALUE_REF_16) {
+            return parseValueRef(input.readUnsignedShort(), ResolvedType.STRING).toString();
+        } else if (typeByte == VALUE_REF_24) {
+            return parseValueRef(input.readUnsignedByte() << 16 + input.readUnsignedShort(), ResolvedType.STRING).toString();
+        } else if (typeByte >= MIN_FIX_STR && typeByte <= MAX_FIX_STR) {
+            size = typeByte - MIN_FIX_STR;
+        } else if (typeByte == STR_8) {
+            size = input.readUnsignedByte();
+        } else if (typeByte == STR_16) {
+            size = input.readUnsignedShort();
+        } else if (typeByte == STR_32) {
+            size = input.readInt();
+        } else {
+            throw invalidBinaryData("string", typeByte);
+        }
+        return acceptStringBytes(size);
+    }
+
+    private String acceptStringBytes(int size) throws IOException {
+        var bytes = new byte[size];
+        input.readFully(bytes);
+        // inline common ASCII case for much better performance
+        var chars = new char[size];
+        for (var i = 0; i < size; i++) {
+            var b = bytes[i];
+            if (b >= 0) {
+                chars[i] = (char) b;
+            } else {
+                return new String(bytes, UTF_8);
+            }
+        }
+        var str = new String(chars);
+        if (str.length() >= JodaBeanPackedBinWriter.MIN_LENGTH_STR_VALUE) {
+            valueDefinitions.add(str);
+        }
+        return str;
+    }
+
+    private int acceptInt() throws IOException {
+        var typeByte = input.readByte();
+        if (typeByte >= MIN_FIX_INT && typeByte <= MAX_FIX_INT) {
+            return typeByte;
+        }
+        return switch (typeByte) {
+            case INT_16 -> input.readShort();
+            case INT_32 -> input.readInt();
+            default -> throw invalidBinaryData("int", typeByte);
+        };
+    }
+
+    private int acceptMap() throws IOException {
+        var typeByte = input.readByte();
+        if (typeByte >= MIN_FIX_MAP && typeByte <= MAX_FIX_MAP) {
+            return typeByte - MIN_FIX_MAP;
+        }
+        return switch (typeByte) {
+            case MAP_8 -> input.readByte();
+            case MAP_16 -> input.readShort();
+            case MAP_32 -> input.readInt();
+            default -> throw invalidBinaryData("map", typeByte);
+        };
+    }
+
+    private int acceptArray() throws IOException {
+        var typeByte = input.readByte();
+        if (typeByte >= MIN_FIX_ARRAY && typeByte <= MAX_FIX_ARRAY) {
+            return typeByte - MIN_FIX_ARRAY;
+        }
+        return switch (typeByte) {
+            case ARRAY_8 -> input.readByte();
+            case ARRAY_16 -> input.readShort();
+            case ARRAY_32 -> input.readInt();
+            default -> throw invalidBinaryData("array", typeByte);
+        };
+    }
+
+    private IllegalArgumentException invalidBinaryData(String expected, int actualByte) {
+        return new IllegalArgumentException(
+                "Invalid binary data: Expected " + expected + ", but was: 0x" + toHex(actualByte));
+    }
+
+    //-------------------------------------------------------------------------
+    private static interface BinHandler {
+        public abstract Object handle(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException;
+    }
+
+    //-------------------------------------------------------------------------
+    private static sealed class BaseBinHandlers {
+
+        // an instance loaded dependent on the classpath
+        private static final BaseBinHandlers INSTANCE = getInstance();
+
+        private static final BaseBinHandlers getInstance() {
+            try {
+                ImmutableGrid.of();  // check if class is available
+                return new CollectBinHandlers();
+            } catch (Exception | LinkageError ex) {
+                try {
+                    ImmutableMultiset.of();  // check if class is available
+                    return new GuavaBinHandlers();
+                } catch (Exception | LinkageError ex2) {
+                    return new BaseBinHandlers();
+                }
+            }
+        }
+
+        BinHandler createHandler(Class<?> type) {
+            if (SortedSet.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseCollection(reader, declType, size, new TreeSet<>());
+            }
+            if (Set.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseCollection(reader, declType, size, LinkedHashSet.newLinkedHashSet(size));
+            }
+            if (Iterable.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseCollection(reader, declType, size, new ArrayList<>(size));
+            }
+            if (SortedMap.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMap(reader, declType, size, new TreeMap<>());
+            }
+            if (Map.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMap(reader, declType, size, LinkedHashMap.newLinkedHashMap(size));
+            }
+            if (Optional.class.isAssignableFrom(type)) {
+                return BaseBinHandlers::parseOptional;
+            }
+            if (type.isArray()) {
+                return BaseBinHandlers::parseArray;
+            }
+            throw new IllegalArgumentException("Invalid binary data: Unknown collection: " + type.getName());
+        }
+
+        Class<?> classForTypeCode(int typeCode) {
+            return switch (typeCode) {
+                case TYPE_CODE_LIST -> List.class;
+                case TYPE_CODE_SET -> Set.class;
+                case TYPE_CODE_MAP -> Map.class;
+                case TYPE_CODE_OPTIONAL -> Optional.class;
+                case TYPE_CODE_OBJECT_ARRAY -> Object[].class;
+                case TYPE_CODE_STRING_ARRAY -> String[].class;
+                default -> throw new IllegalArgumentException("Invalid binary data: Unknown type code: " + typeCode);
+            };
+        }
+
+        // collection - parsed from a BeanPack array
+        private static Collection<?> parseCollection(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size,
+                Collection<Object> collection) throws IOException {
+
+            var itemType = declaredType.getArgumentOrDefault(0);
+            for (var i = 0; i < size; i++) {
+                collection.add(reader.parseObject(itemType));
+            }
+            return collection;
+        }
+
+        // map - parsed from a BeanPack map
+        static Map<?, ?> parseMap(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size,
+                Map<Object, Object> map) throws IOException {
+
+            var keyType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(1);
+            for (var i = 0; i < size; i++) {
+                var key = reader.parseObject(keyType);
+                var value = reader.parseObject(valueType);
+                map.put(key, value);
+            }
+            return map;
+        }
+
+        // optional - parsed from a BeanPack array, size 0 or 1
+        private static Optional<?> parseOptional(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            return switch (size) {
+                case 0 -> Optional.empty();
+                case 1 -> {
+                    var itemType = declaredType.getArgumentOrDefault(0);
+                    var value = reader.parseObject(itemType);
+                    yield Optional.ofNullable(value);
+                }
+                default -> throw new IllegalArgumentException(
+                        "Invalid binary data: Optional must be an array of size zero or one, but was " + size);
+            };
+        }
+
+        // array - parsed from a BeanPack array
+        private static Object parseArray(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            var componentType = declaredType.toComponentType();
+            var array = Array.newInstance(componentType.getRawType(), size);
+            for (var i = 0; i < size; i++) {
+                Array.set(array, i, reader.parseObject(componentType));
+            }
+            return array;
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    private static sealed class GuavaBinHandlers extends BaseBinHandlers {
+
+        @Override
+        BinHandler createHandler(Class<?> type) {
+            if (SortedMultiset.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMultiset(reader, declType, size, TreeMultiset.create());
+            }
+            if (Multiset.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMultiset(reader, declType, size, HashMultiset.create());
+            }
+            if (SetMultimap.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMultimap(reader, declType, size, HashMultimap.create());
+            }
+            if (Multimap.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMultimap(reader, declType, size, ArrayListMultimap.create());
+            }
+            if (Table.class.isAssignableFrom(type)) {
+                return GuavaBinHandlers::parseTable;
+            }
+            if (BiMap.class.isAssignableFrom(type)) {
+                return (reader, declType, size) -> parseMap(reader, declType, size, HashBiMap.create());
+            }
+            if (com.google.common.base.Optional.class.isAssignableFrom(type)) {
+                return GuavaBinHandlers::parseOptional;
+            }
+            // these are optimizations, so don't match subtypes like ImmutableSortedSet or ImmutableSortedMap
+            if (ImmutableSet.class == type) {
+                return (reader, declType, size) -> parseImmutableCollection(
+                        reader, declType, size, ImmutableSet.builderWithExpectedSize(size));
+            }
+            if (ImmutableList.class == type) {
+                return (reader, declType, size) -> parseImmutableCollection(
+                        reader, declType, size, ImmutableList.builderWithExpectedSize(size));
+            }
+            if (ImmutableMap.class == type) {
+                return (reader, declType, size) -> parseImmutableMap(reader, declType, size);
+            }
+            return super.createHandler(type);
+        }
+
+        @Override
+        Class<?> classForTypeCode(int typeCode) {
+            return switch (typeCode) {
+                case TYPE_CODE_MULTISET -> Multiset.class;
+                case TYPE_CODE_LIST_MULTIMAP -> ListMultimap.class;
+                case TYPE_CODE_SET_MULTIMAP -> SetMultimap.class;
+                case TYPE_CODE_TABLE -> Table.class;
+                case TYPE_CODE_BIMAP -> BiMap.class;
+                case TYPE_CODE_GUAVA_OPTIONAL -> com.google.common.base.Optional.class;
+                default -> super.classForTypeCode(typeCode);
+            };
+        }
+
+        // multiset - parsed from a BeanPack map of value to count
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private static Multiset<?> parseMultiset(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size,
+                Multiset mset) throws IOException {
+
+            var itemType = declaredType.getArgumentOrDefault(0);
+            for (var i = 0; i < size; i++) {
+                var item = reader.parseObject(itemType);
+                var count = reader.acceptInt();
+                mset.add(item, count);
+            }
+            return mset;
+        }
+
+        // multimap - parsed from a BeanPack map of key to array of values
+        private static Multimap<?, ?> parseMultimap(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size,
+                Multimap<Object, Object> mmap) throws IOException {
+
+            var keyType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(1);
+            for (var i = 0; i < size; i++) {
+                var key = reader.parseObject(keyType);
+                var valueSize = reader.acceptArray();
+                for (var j = 0; j < valueSize; j++) {
+                    var value = reader.parseObject(valueType);
+                    mmap.put(key, value);
+                }
+            }
+            return mmap;
+        }
+
+        // table - parsed from a BeanPack map of row to map of column to value
+        private static Table<?, ?, ?> parseTable(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            var rowType = declaredType.getArgumentOrDefault(0);
+            var columnType = declaredType.getArgumentOrDefault(1);
+            var valueType = declaredType.getArgumentOrDefault(2);
+            var table = HashBasedTable.create();
+            for (var i = 0; i < size; i++) {
+                var row = reader.parseObject(rowType);
+                var colSize = reader.acceptMap();
+                for (var j = 0; j < colSize; j++) {
+                    var column = reader.parseObject(columnType);
+                    var value = reader.parseObject(valueType);
+                    table.put(row, column, value);
+                }
+            }
+            return table;
+        }
+
+        // optional - parsed from a BeanPack array, size 0 or 1
+        private static com.google.common.base.Optional<?> parseOptional(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            return switch (size) {
+                case 0 -> com.google.common.base.Optional.absent();
+                case 1 -> {
+                    var itemType = declaredType.getArgumentOrDefault(0);
+                    var value = reader.parseObject(itemType);
+                    yield com.google.common.base.Optional.fromNullable(value);
+                }
+                default -> throw new IllegalArgumentException(
+                        "Invalid binary data: Optional must be an array of size zero or one, but was " + size);
+            };
+        }
+
+        // immutable collection - optimizes using builder and expected size
+        private static ImmutableCollection<?> parseImmutableCollection(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size,
+                ImmutableCollection.Builder<Object> builder) throws IOException {
+
+            var itemType = declaredType.getArgumentOrDefault(0);
+            for (var i = 0; i < size; i++) {
+                var item = reader.parseObject(itemType);
+                builder.add(item);
+            }
+            return builder.build();
+        }
+
+        // immutable map - optimizes using builder and expected size
+        private static ImmutableMap<?, ?> parseImmutableMap(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            var builder = ImmutableMap.builderWithExpectedSize(size);
+            var keyType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(1);
+            for (var i = 0; i < size; i++) {
+                var key = reader.parseObject(keyType);
+                var value = reader.parseObject(valueType);
+                builder.put(key, value);
+            }
+            return builder.build();
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    private static final class CollectBinHandlers extends GuavaBinHandlers {
+
+        @Override
+        BinHandler createHandler(Class<?> type) {
+            if (Grid.class.isAssignableFrom(type)) {
+                return CollectBinHandlers::parseGrid;
+            }
+            return super.createHandler(type);
+        }
+
+        @Override
+        Class<?> classForTypeCode(int typeCode) {
+            return switch (typeCode) {
+                case TYPE_CODE_GRID -> Grid.class;
+                default -> super.classForTypeCode(typeCode);
+            };
+        }
+
+        // grid
+        private static Grid<?> parseGrid(
+                JodaBeanPackedBinReader reader,
+                ResolvedType declaredType,
+                int size) throws IOException {
+
+            var valueType = declaredType.getArgumentOrDefault(0);
+            if (size != 3) {
+                throw new IllegalArgumentException(
+                        "Invalid binary data: Grid must be an array of size three, but was " + size);
+            }
+            var rowCount = reader.acceptInt();
+            var colCount = reader.acceptInt();
+            var arraySize = reader.acceptArray();
+            if (rowCount < 0) {
+                // dense
+                rowCount = -rowCount;
+                var grid = DenseGrid.create(rowCount, colCount);
+                for (var row = 0; row < rowCount; row++) {
+                    for (var col = 0; col < colCount; col++) {
+                        var value = reader.parseObject(valueType);
+                        if (value != null) {
+                            grid.put(row, col, value);
+                        }
+                    }
+                }
+                return grid;
+            } else {
+                // sparse
+                var grid = SparseGrid.create(rowCount, colCount);
+                for (var i = 0; i < arraySize / 3; i++) {
+                    var row = reader.acceptInt();
+                    var col = reader.acceptInt();
+                    var value = reader.parseObject(valueType);
+                    if (value != null) {
+                        grid.put(row, col, value);
+                    }
+                }
+                return grid;
+            }
+        }
+    }
+}

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
@@ -1,0 +1,831 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser.bin;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
+
+import org.joda.beans.Bean;
+import org.joda.beans.DynamicBean;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.ResolvedType;
+import org.joda.beans.impl.flexi.FlexiBean;
+import org.joda.beans.impl.map.MapBean;
+import org.joda.beans.ser.JodaBeanSer;
+import org.joda.beans.ser.SerTypeMapper;
+import org.joda.collect.grid.Grid;
+import org.joda.collect.grid.ImmutableGrid;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Table;
+
+/**
+ * Writes the Joda-Bean BeanPack binary format with strings deduplicated by reference.
+ * <p>
+ * This class contains mutable state and cannot be used from multiple threads.
+ * A new instance must be created for each message.
+ */
+final class JodaBeanPackedBinWriter {
+
+    static final int MIN_LENGTH_STR_VALUE = 3;
+
+    // why is there an ugly ClassValue setup here?
+    // because this is O(1) whereas switch with pattern match which is O(n)
+    private static final ClassValue<BinHandler<Object>> LOOKUP = new ClassValue<>() {
+
+        @SuppressWarnings("rawtypes")  // sneaky use of raw type to allow typed value in each method below
+        @Override
+        protected BinHandler computeValue(Class<?> type) {
+            if (Bean.class.isAssignableFrom(type)) {
+                return (BinHandler<Bean>) JodaBeanPackedBinWriter::writeBeanMaybeSimple;
+            }
+            // these primitive types are always written and interpretted without a type
+            if (type == String.class) {
+                return (writer, declaredType, propName, value) -> writer.writeString((String) value);
+            }
+            if (type == Integer.class || type == int.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeInt((Integer) value);
+            }
+            if (type == Long.class || type == long.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeLong((Long) value);
+            }
+            if (type == Byte.class || type == byte.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeByte((Byte) value);
+            }
+            if (type == Short.class || type == short.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeShort((Short) value);
+            }
+            if (type == Character.class || type == char.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeChar((Character) value);
+            }
+            if (type == Double.class || type == double.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeDouble((Double) value);
+            }
+            if (type == Float.class || type == float.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeFloat((Float) value);
+            }
+            if (type == Boolean.class || type == boolean.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeBoolean((Boolean) value);
+            }
+            if (type == LocalDate.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeDate((LocalDate) value);
+            }
+            if (type == LocalTime.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeTime((LocalTime) value);
+            }
+            if (type == Instant.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeInstant((Instant) value);
+            }
+            if (type == Duration.class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeDuration((Duration) value);
+            }
+            return BaseBinHandlers.INSTANCE.createHandler(type);
+        }
+    };
+
+    /**
+     * The settings to use.
+     */
+    private final JodaBeanSer settings;
+    /**
+     * The outputter.
+     */
+    private final BeanPackOutput output;
+
+    /**
+     * The base package including the trailing dot.
+     */
+    private String basePackage;
+    /**
+     * The known types.
+     */
+    private final Map<Class<?>, String> knownTypes = new IdentityHashMap<>();
+    /**
+     * The type definitions that have been output.
+     */
+    private int typeDefinitionIndex;
+    /**
+     * The type definitions that have been output.
+     */
+    private final Map<Class<?>, Integer> typeDefinitions = new IdentityHashMap<>();
+    /**
+     * The bean definitions.
+     */
+    private final Map<Class<?>, List<MetaProperty<?>>> beanDefinitions = new IdentityHashMap<>();
+    /**
+     * The type definitions that have been output.
+     */
+    private int valueDefinitionIndex;
+    /**
+     * The value definitions that have been output.
+     */
+    private final Map<Object, Integer> valueDefinitions = new HashMap<>();
+
+    /**
+     * Creates an instance.
+     * 
+     * @param settings  the settings to use, not null
+     * @param out  the output stream, not null
+     */
+    JodaBeanPackedBinWriter(JodaBeanSer settings, OutputStream out) {
+        this.settings = settings;
+        this.output = new BeanPackOutput(out);
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Writes the bean to the {@code OutputStream}.
+     * 
+     * @param bean  the bean to output, not null
+     * @param includeRootType  whether to include the root type
+     * @throws IOException if an error occurs
+     */
+    void write(Bean bean, boolean includeRootType) throws IOException {
+        var beanClass = bean.getClass();
+        // these first two bytes in BeanPack are compatible with MsgPack!
+        output.writeArrayHeader(3);
+        output.writeInt(3);  // version 3
+        if (includeRootType && beanClass != FlexiBean.class && beanClass != MapBean.class && settings.isShortTypes()) {
+            basePackage = beanClass.getPackage().getName() + '.';
+            SerTypeMapper.encodeType(beanClass, settings, basePackage, knownTypes);
+            writeString(basePackage);
+        } else {
+            basePackage = null;
+            output.writeNull();
+        }
+
+        // root always outputs the bean, not Joda-Convert form
+        writeBean(ResolvedType.of(beanClass), bean, includeRootType);
+        if (typeDefinitionIndex > 0xFFFF) {
+            throw new IllegalArgumentException("Invalid bindary data: Too many type references");
+        }
+        if (valueDefinitionIndex > 0xFFFFFF) {
+            throw new IllegalArgumentException("Invalid bindary data: Too many value references");
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    // writes an object, by determining the runtime type
+    private void writeObject(ResolvedType declaredType, String propertyName, Object value) throws IOException {
+        if (value == null) {
+            output.writeNull();
+        } else {
+            var handler = LOOKUP.get(value.getClass());
+            handler.handle(this, declaredType, propertyName, value);
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // writes a bean, favouring output as a Joda-Convert type
+    private void writeBeanMaybeSimple(ResolvedType declaredType, String propertyName, Bean bean) throws IOException {
+        // check for Joda-Convert cannot be in ClassValue as it relies on the settings
+        // cannot call valueDefinitions.get(value) here, as hashCode() of a random bean may be very expensive
+        if (settings.getConverter().isConvertible(bean.getClass())) {
+            writeSimple(propertyName, bean);
+        } else if (settings.getBeanValueClasses().contains(bean.getClass())) {
+            writeCachedBean(bean);
+        } else {
+            writeBean(declaredType, bean, true);
+        }
+    }
+
+    // writes a bean, where the bean is a value that can be cached
+    private void writeCachedBean(Bean bean) throws IOException {
+        // note that the declared type is not used to refine the output, creating separation of types in the binary form
+        var ref = valueDefinitions.get(bean);
+        if (ref == null) {
+            // always write the type, as it could be read while skipping where the type is not known
+            output.writeValueDefinitionHeader();
+            writeTypeNameOrReference(bean.getClass());
+
+            var beanClass = bean.getClass();
+            var metaProperties = beanDefinitions.get(beanClass);
+            if (metaProperties == null) {
+                writeBeanWithDefinition(bean);
+            } else {
+                writeBeanValues(bean, metaProperties);
+            }
+            valueDefinitions.put(bean, valueDefinitionIndex++);
+        } else {
+            output.writeValueReference(ref);
+        }
+    }
+
+    // writes a bean, with meta type information if necessary
+    private void writeBean(ResolvedType declaredType, Bean bean, boolean includeRootType) throws IOException {
+        var beanClass = bean.getClass();
+        var metaProperties = beanDefinitions.get(beanClass);
+        if (metaProperties == null) {
+            if (bean instanceof DynamicBean || !includeRootType) {
+                if (beanClass != declaredType.getRawType()) {
+                    writeTypeNameOrReference(beanClass);
+                }
+                writeDynamicBean(bean);
+            } else {
+                // always write the type, as it could be read while skipping where the type is not known
+                writeTypeNameOrReference(beanClass);
+                writeBeanWithDefinition(bean);
+            }
+        } else {
+            if (beanClass != declaredType.getRawType()) {
+                writeTypeNameOrReference(beanClass);
+            }
+            writeBeanValues(bean, metaProperties);
+        }
+    }
+
+    // writes the dynamic bean as a map of property name to property value, without any type information
+    private void writeDynamicBean(Bean bean) throws IOException {
+        // note that the declared type is not used to refine the output, creating separation of types in the binary form
+        var beanClass = bean.getClass();
+        var metaBean = bean.metaBean();
+        var beanMap = new LinkedHashMap<MetaProperty<?>, Object>(metaBean.metaPropertyCount());
+        for (var metaProperty : metaBean.metaPropertyIterable()) {
+            if (settings.isSerialized(metaProperty)) {
+                var value = metaProperty.get(bean);
+                if (value != null) {
+                    beanMap.put(metaProperty, value);
+                }
+            }
+        }
+        output.writeMapHeader(beanMap.size());
+        for (var entry : beanMap.entrySet()) {
+            var metaProperty = entry.getKey();
+            var value = entry.getValue();
+            var resolvedType = metaProperty.propertyResolvedType(beanClass);
+            var childPropertyName = metaProperty.name();
+            if (value != null) {
+                writeString(childPropertyName);
+                writeObject(resolvedType, childPropertyName, value);
+            }
+        }
+    }
+
+    // writes the bean definition structure
+    private void writeBeanWithDefinition(Bean bean) throws IOException {
+        // note that the declared type is not used to refine the output, creating separation of types in the binary form
+        var metaProperties = findSerializedMetaProperties(bean);
+        if (metaProperties.size() > 255) {
+            writeDynamicBean(bean);
+        } else {
+            var beanClass = bean.getClass();
+            beanDefinitions.put(beanClass, metaProperties);
+            output.writeBeanDefinitionHeader(metaProperties.size());
+            for (var metaProperty : metaProperties) {
+                writeString(metaProperty.name());
+            }
+            for (var metaProperty : metaProperties) {
+                var resolvedType = metaProperty.propertyResolvedType(beanClass);
+                var childPropertyName = metaProperty.name();
+                var value = metaProperty.get(bean);
+                writeObject(resolvedType, childPropertyName, value);
+            }
+        }
+    }
+
+    // find the list of meta properties that will be serialized
+    private ArrayList<MetaProperty<?>> findSerializedMetaProperties(Bean bean) {
+        var metaBean = bean.metaBean();
+        var metaProperties = new ArrayList<MetaProperty<?>>(metaBean.metaPropertyCount());
+        for (var metaProperty : metaBean.metaPropertyIterable()) {
+            if (settings.isSerialized(metaProperty)) {
+                metaProperties.add(metaProperty);
+            }
+        }
+        return metaProperties;
+    }
+
+    // writes the bean values without property names, effectively referring back to the original definition
+    private void writeBeanValues(Bean bean, List<MetaProperty<?>> metaProperties) throws IOException {
+        // note that the declared type is not used to refine the output, creating separation of types in the binary form
+        var beanClass = bean.getClass();
+        output.writeArrayHeader(metaProperties.size());
+        for (var metaProperty : metaProperties) {
+            if (settings.isSerialized(metaProperty)) {
+                var resolvedType = metaProperty.propertyResolvedType(beanClass);
+                var childPropertyName = metaProperty.name();
+                var value = metaProperty.get(bean);
+                writeObject(resolvedType, childPropertyName, value);
+            }
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    // writes a string
+    private void writeString(String str) throws IOException {
+        if (str.length() >= MIN_LENGTH_STR_VALUE) {
+            var ref = valueDefinitions.get(str);
+            if (ref == null) {
+                valueDefinitions.put(str, valueDefinitionIndex++);
+                output.writeString(str);
+            } else {
+                output.writeValueReference(ref);
+            }
+        } else {
+            output.writeString(str);
+        }
+    }
+
+    // writes a simple type, with meta type information if necessary
+    // this method is never called for primitive types like int/long/LocalDate
+    private void writeSimple(String propertyName, Object value) throws IOException {
+        // note that the declared type is not used to refine the output, creating separation of types in the binary form
+        // write the reference, or call Joda-Convert if first time value is seen
+        var ref = valueDefinitions.get(value);
+        if (ref == null) {
+            // always write the type (by passing OBJECT), as it could be read while skipping where the type is not known
+            output.writeValueDefinitionHeader();
+            writeJodaConvert(ResolvedType.OBJECT, propertyName, value);
+            valueDefinitions.put(value, valueDefinitionIndex++);
+        } else {
+            output.writeValueReference(ref);
+        }
+    }
+
+    // writes the object as a String using Joda-Convert
+    private void writeJodaConvert(ResolvedType declaredType, String propertyName, Object value) throws IOException {
+        try {
+            // handle situations where there is no declared type, or there is a subclass of the declared type
+            var effectiveType = value.getClass();
+            var converter = settings.getConverter().findTypedConverterNoGenerics(effectiveType);
+            if (effectiveType != declaredType.toBoxed().getRawType()) {
+                effectiveType = converter.getEffectiveType();
+                writeTypeNameOrReference(effectiveType);
+            }
+            var converted = converter.convertToString(value);
+            if (converted == null) {
+                output.writeNull();
+                return;
+            }
+            writeString(converted);
+        } catch (RuntimeException ex) {
+            throw invalidConversionMsg(propertyName, value, ex);
+        }
+    }
+
+    private IllegalArgumentException invalidConversionMsg(String propertyName, Object value, RuntimeException ex) {
+        var msg = "Unable to write property '" + propertyName + "', type " +
+                value.getClass().getName() + " could not be converted to a String";
+        return new IllegalArgumentException(msg, ex);
+    }
+
+    // writes the type header
+    private final void writeTypeNameOrReference(Class<?> type) throws IOException {
+        var ref = typeDefinitions.get(type);
+        if (ref == null) {
+            var encodedClassName = SerTypeMapper.encodeType(type, settings, basePackage, knownTypes);
+            typeDefinitions.put(type, typeDefinitionIndex++);
+            output.writeTypeName(encodedClassName);
+        } else {
+            output.writeTypeReference(ref);
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    private static interface BinHandler<T> {
+        public abstract void handle(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                T obj) throws IOException;
+    }
+
+    //-------------------------------------------------------------------------
+    // handles base JDK collections
+    private static sealed class BaseBinHandlers {
+
+        // an instance loaded dependent on the classpath
+        private static final BaseBinHandlers INSTANCE = getInstance();
+
+        private static final BaseBinHandlers getInstance() {
+            try {
+                ImmutableGrid.of();  // check if class is available
+                return new CollectBinHandlers();
+            } catch (Exception | LinkageError ex) {
+                try {
+                    ImmutableMultiset.of();  // check if class is available
+                    return new GuavaBinHandlers();
+                } catch (Exception | LinkageError ex2) {
+                    return new BaseBinHandlers();
+                }
+            }
+        }
+
+        // creates the handler, called from ClassValue.computeValue()
+        BinHandler<?> createHandler(Class<?> type) {
+            if (Optional.class.isAssignableFrom(type)) {
+                return (BinHandler<Optional<?>>) BaseBinHandlers::writeOptional;
+            }
+            if (type == byte[].class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeBytes((byte[]) value);
+            }
+            if (type == double[].class) {
+                return (writer, declaredType, propName, value) -> writer.output.writeDoubles((double[]) value);
+            }
+            if (type.isArray()) {
+                var componentType = type.getComponentType();
+                if (componentType.isPrimitive()) {
+                    return (BinHandler<Object>) BaseBinHandlers::writePrimitiveArray;
+                } else {
+                    return (BinHandler<Object[]>) BaseBinHandlers::writeArray;
+                }
+            }
+            if (Collection.class.isAssignableFrom(type)) {
+                return (BinHandler<Collection<?>>) BaseBinHandlers::writeCollection;
+            }
+            if (Iterable.class.isAssignableFrom(type)) {
+                return (BinHandler<Iterable<?>>) BaseBinHandlers::writeIterable;
+            }
+            if (Map.class.isAssignableFrom(type)) {
+                return (BinHandler<Map<?, ?>>) BaseBinHandlers::writeMap;
+            }
+            return (writer, declaredType, propertyName, value) -> writer.writeSimple(propertyName, value);
+        }
+
+        // writes an optional, with meta type information if necessary
+        private static void writeOptional(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Optional<?> opt) throws IOException {
+
+            // write actual type
+            if (!Optional.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_OPTIONAL);
+            }
+            // write content, using an array of size 0 or 1
+            var valueType = declaredType.getArgumentOrDefault(0);
+            if (opt.isEmpty()) {
+                writer.output.writeArrayHeader(0);
+            } else {
+                writer.output.writeArrayHeader(1);
+                writer.writeObject(valueType, "", opt.get());
+            }
+        }
+
+        // writes an array, with meta type information if necessary
+        private static void writeArray(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Object[] array) throws IOException {
+
+            // write actual type
+            var actualComponentType = array.getClass().getComponentType();
+            if (!declaredType.isArray() || declaredType.getRawType().getComponentType() != actualComponentType) {
+                if (actualComponentType == String.class) {
+                    writer.output.writeTypeReference(BeanPack.TYPE_CODE_STRING_ARRAY);
+                } else if (actualComponentType == Object.class) {
+                    writer.output.writeTypeReference(BeanPack.TYPE_CODE_OBJECT_ARRAY);
+                } else {
+                    writeArrayTypeDescription(writer, array.getClass());
+                }
+            }
+            // write content
+            var componentType = declaredType.toComponentTypeOrDefault();
+            writer.output.writeArrayHeader(array.length);
+            for (var item : array) {
+                writer.writeObject(componentType, "", item);
+            }
+        }
+
+        // writes a primitive array, with meta type information if necessary
+        private static void writePrimitiveArray(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Object array) throws IOException {
+
+            // write actual type
+            var arrayType = array.getClass();
+            if (!declaredType.isArray()) {
+                writeArrayTypeDescription(writer, arrayType);
+            }
+            // write content
+            var handler = JodaBeanPackedBinWriter.LOOKUP.get(arrayType.getComponentType());
+            var arrayLength = Array.getLength(array);
+            writer.output.writeArrayHeader(arrayLength);
+            for (int i = 0; i < arrayLength; i++) {
+                handler.handle(writer, declaredType, propertyName, Array.get(array, i));
+            }
+        }
+
+        // writes the meta type header
+        private static final void writeArrayTypeDescription(JodaBeanPackedBinWriter writer, Class<?> arrayType) throws IOException {
+            var ref = writer.typeDefinitions.get(arrayType);
+            if (ref == null) {
+                var encodedClassName = metaTypeArrayName(arrayType.getComponentType());
+                writer.typeDefinitions.put(arrayType, writer.typeDefinitionIndex++);
+                writer.output.writeTypeName(encodedClassName);
+            } else {
+                writer.output.writeTypeReference(ref);
+            }
+        }
+
+        // determines the meta type name to use
+        private static String metaTypeArrayName(Class<?> valueType) {
+            if (valueType.isArray()) {
+                return metaTypeArrayName(valueType.getComponentType()) + "[]";
+            }
+            if (valueType == Object.class) {
+                return "Object[]";
+            }
+            if (valueType == String.class) {
+                return "String[]";
+            }
+            return valueType.getName() + "[]";
+        }
+
+        // writes a collection, with meta type information if necessary
+        private static void writeIterable(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Iterable<?> iterable) throws IOException {
+
+            // convert to a list, which is necessary as there is no size() on Iterable
+            // this ensures that the generics of the iterable are retained
+            var list = StreamSupport.stream(iterable::spliterator, Spliterator.ORDERED, false).toList();
+            var adjustedType = ResolvedType.of(List.class, declaredType.getArguments());
+            writeCollection(writer, adjustedType, propertyName, list);
+        }
+
+        // writes a collection, with meta type information if necessary
+        private static void writeCollection(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Collection<?> coll) throws IOException {
+
+            // write actual type
+            if (coll instanceof Set && !Set.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_SET);
+            } else if (!Collection.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_LIST);
+            }
+            // write content
+            var itemType = declaredType.getArgumentOrDefault(0);
+            writer.output.writeArrayHeader(coll.size());
+            for (var item : coll) {
+                writer.writeObject(itemType, "", item);
+            }
+        }
+
+        // writes a map, with meta type information if necessary
+        private static void writeMap(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Map<?, ?> map) throws IOException {
+
+            // write actual type
+            if (!Map.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_MAP);
+            }
+            // write content
+            writeMapEntries(writer, declaredType, propertyName, map.entrySet());
+        }
+
+        // writes a map given map entries, code shared with Multimap
+        static <K, V> void writeMapEntries(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Collection<Map.Entry<K, V>> mapEntries) throws IOException {
+
+            var keyType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(1);
+            writer.output.writeMapHeader(mapEntries.size());
+            for (var entry : mapEntries) {
+                writer.writeObject(keyType, "", entry.getKey());
+                writer.writeObject(valueType, "", entry.getValue());
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    private static sealed class GuavaBinHandlers extends BaseBinHandlers {
+
+        @Override
+        BinHandler<?> createHandler(Class<?> type) {
+            if (com.google.common.base.Optional.class.isAssignableFrom(type)) {
+                return (BinHandler<com.google.common.base.Optional<?>>) GuavaBinHandlers::writeOptional;
+            }
+            if (Multimap.class.isAssignableFrom(type)) {
+                return (BinHandler<Multimap<?, ?>>) GuavaBinHandlers::writeMultimap;
+            }
+            if (Multiset.class.isAssignableFrom(type)) {
+                return (BinHandler<Multiset<?>>) GuavaBinHandlers::writeMultiset;
+            }
+            if (Table.class.isAssignableFrom(type)) {
+                return (BinHandler<Table<?, ?, ?>>) GuavaBinHandlers::writeTable;
+            }
+            if (BiMap.class.isAssignableFrom(type)) {
+                return (BinHandler<BiMap<?, ?>>) GuavaBinHandlers::writeBiMap;
+            }
+            return super.createHandler(type);
+        }
+
+        // writes an optional, with meta type information if necessary
+        private static void writeOptional(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                com.google.common.base.Optional<?> opt) throws IOException {
+
+            // write actual type
+            if (!com.google.common.base.Optional.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_OPTIONAL);
+            }
+            // write content, using an array of size 0 or 1
+            var valueType = declaredType.getArgumentOrDefault(0);
+            if (opt.isPresent()) {
+                writer.output.writeArrayHeader(1);
+                writer.writeObject(valueType, "", opt.get());
+            } else {
+                writer.output.writeArrayHeader(0);
+            }
+        }
+
+        // writes a multimap, with meta type information if necessary
+        private static void writeMultimap(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Multimap<?, ?> mmap) throws IOException {
+
+            // write actual type
+            if (mmap instanceof SetMultimap && !SetMultimap.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_SET_MULTIMAP);
+            } else if (!Multimap.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_LIST_MULTIMAP);
+            }
+            // write content, using a map of key to array of values
+            var keyType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(1);
+            var map = mmap.asMap();
+            writer.output.writeMapHeader(map.size());
+            for (var entry : map.entrySet()) {
+                writer.writeObject(keyType, "", entry.getKey());
+                var values = entry.getValue();
+                writer.output.writeArrayHeader(values.size());
+                for (var value : values) {
+                    writer.writeObject(valueType, "", value);
+                }
+            }
+        }
+
+        // writes a multiset, with meta type information if necessary
+        private static void writeMultiset(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Multiset<?> mset) throws IOException {
+
+            // write actual type
+            if (!Multiset.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_MULTISET);
+            }
+            // write content, using a map of value to count
+            var valueType = declaredType.getArgumentOrDefault(0);
+            var entrySet = mset.entrySet();
+            writer.output.writeMapHeader(entrySet.size());
+            for (var entry : entrySet) {
+                writer.writeObject(valueType, "", entry.getElement());
+                writer.output.writeInt(entry.getCount());
+            }
+        }
+
+        // writes a table, with meta type information if necessary
+        private static void writeTable(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Table<?, ?, ?> table) throws IOException {
+
+            // write actual type
+            if (!Table.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_TABLE);
+            }
+            // write content, using a map of row to map of column to value
+            var rowType = declaredType.getArgumentOrDefault(0);
+            var columnType = declaredType.getArgumentOrDefault(1);
+            var valueType = declaredType.getArgumentOrDefault(2);
+            var rowMap = table.rowMap();
+            writer.output.writeMapHeader(rowMap.size());
+            for (var rowEntry : rowMap.entrySet()) {
+                writer.writeObject(rowType, "", rowEntry.getKey());
+                writer.output.writeMapHeader(rowEntry.getValue().size());
+                for (var colEntry : rowEntry.getValue().entrySet()) {
+                    writer.writeObject(columnType, "", colEntry.getKey());
+                    writer.writeObject(valueType, "", colEntry.getValue());
+                }
+            }
+        }
+
+        // writes a BiMap, with meta type information if necessary
+        private static void writeBiMap(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                BiMap<?, ?> biMap) throws IOException {
+
+            // write actual type
+            if (!BiMap.class.isAssignableFrom(declaredType.getRawType())) {
+                // hack around Guava annoyance by assuming that size 0 and 1 ImmutableBiMap
+                // was actually meant to be an ImmutableMap
+                if ((declaredType.getRawType() != Map.class && declaredType.getRawType() != ImmutableMap.class) || biMap.size() >= 2) {
+                    writer.output.writeTypeReference(BeanPack.TYPE_CODE_BIMAP);
+                }
+            }
+            // write content
+            writeMapEntries(writer, declaredType, propertyName, biMap.entrySet());
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    private static final class CollectBinHandlers extends GuavaBinHandlers {
+
+        @Override
+        BinHandler<?> createHandler(Class<?> type) {
+            if (Grid.class.isAssignableFrom(type)) {
+                return (BinHandler<Grid<?>>) CollectBinHandlers::writeGrid;
+            }
+            return super.createHandler(type);
+        }
+
+        // writes a grid, with meta type information if necessary
+        private static void writeGrid(
+                JodaBeanPackedBinWriter writer,
+                ResolvedType declaredType,
+                String propertyName,
+                Grid<?> grid) throws IOException {
+
+            // write actual type
+            if (!Grid.class.isAssignableFrom(declaredType.getRawType())) {
+                writer.output.writeTypeReference(BeanPack.TYPE_CODE_GRID);
+            }
+            // write content using sparse or dense approach
+            var valueType = declaredType.getArgumentOrDefault(0);
+            var rowCount = grid.rowCount();
+            var colCount = grid.columnCount();
+            var totalSize = rowCount * colCount;
+            var gridSize = grid.size();
+            var sparse = gridSize <= (totalSize / 3d);
+            writer.output.writeArrayHeader(3);
+            writer.output.writeInt(sparse ? rowCount : -rowCount);
+            writer.output.writeInt(colCount);
+            if (sparse) {
+                // sparse
+                writer.output.writeArrayHeader(gridSize * 3);
+                for (var cell : grid.cells()) {
+                    writer.output.writeInt(cell.getRow());
+                    writer.output.writeInt(cell.getColumn());
+                    writer.writeObject(valueType, "", cell.getValue());
+                }
+            } else {
+                // dense
+                writer.output.writeArrayHeader(totalSize);
+                for (var row = 0; row < rowCount; row++) {
+                    for (var column = 0; column < colCount; column++) {
+                        writer.writeObject(valueType, "", grid.get(row, column));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/joda/beans/ser/bin/TestSerializePackedBin.java
+++ b/src/test/java/org/joda/beans/ser/bin/TestSerializePackedBin.java
@@ -1,0 +1,1143 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser.bin;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.assertj.core.api.Assertions.offset;
+import static org.joda.beans.ser.bin.BeanPack.BIN_16;
+import static org.joda.beans.ser.bin.BeanPack.BIN_8;
+import static org.joda.beans.ser.bin.BeanPack.BYTE_8;
+import static org.joda.beans.ser.bin.BeanPack.CHAR_16;
+import static org.joda.beans.ser.bin.BeanPack.DATE;
+import static org.joda.beans.ser.bin.BeanPack.DATE_PACKED;
+import static org.joda.beans.ser.bin.BeanPack.DOUBLE_64;
+import static org.joda.beans.ser.bin.BeanPack.DOUBLE_ARRAY_16;
+import static org.joda.beans.ser.bin.BeanPack.DOUBLE_ARRAY_8;
+import static org.joda.beans.ser.bin.BeanPack.DOUBLE_INT_8;
+import static org.joda.beans.ser.bin.BeanPack.DURATION;
+import static org.joda.beans.ser.bin.BeanPack.FLOAT_32;
+import static org.joda.beans.ser.bin.BeanPack.INSTANT;
+import static org.joda.beans.ser.bin.BeanPack.INT_16;
+import static org.joda.beans.ser.bin.BeanPack.INT_32;
+import static org.joda.beans.ser.bin.BeanPack.LONG_16;
+import static org.joda.beans.ser.bin.BeanPack.LONG_32;
+import static org.joda.beans.ser.bin.BeanPack.LONG_64;
+import static org.joda.beans.ser.bin.BeanPack.LONG_8;
+import static org.joda.beans.ser.bin.BeanPack.MIN_FIX_STR;
+import static org.joda.beans.ser.bin.BeanPack.SHORT_16;
+import static org.joda.beans.ser.bin.BeanPack.STR_8;
+import static org.joda.beans.ser.bin.BeanPack.TIME;
+import static org.joda.beans.ser.bin.BeanPack.TYPE_CODE_GRID;
+import static org.joda.beans.ser.bin.BeanPack.UTF_8;
+import static org.joda.beans.ser.bin.JodaBeanBinFormat.PACKED;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.impl.flexi.FlexiBean;
+import org.joda.beans.sample.Address;
+import org.joda.beans.sample.Company;
+import org.joda.beans.sample.ImmAddress;
+import org.joda.beans.sample.ImmArrays;
+import org.joda.beans.sample.ImmDefault;
+import org.joda.beans.sample.ImmDoubleFloat;
+import org.joda.beans.sample.ImmGuava;
+import org.joda.beans.sample.ImmKey;
+import org.joda.beans.sample.ImmKeyList;
+import org.joda.beans.sample.ImmNamedKey;
+import org.joda.beans.sample.ImmOptional;
+import org.joda.beans.sample.ImmPerson;
+import org.joda.beans.sample.JodaConvertBean;
+import org.joda.beans.sample.JodaConvertWrapper;
+import org.joda.beans.sample.Pair;
+import org.joda.beans.sample.PrimitiveBean;
+import org.joda.beans.sample.RiskLevel;
+import org.joda.beans.sample.TupleFinal;
+import org.joda.beans.ser.JodaBeanSer;
+import org.joda.beans.ser.SerDeserializers;
+import org.joda.beans.ser.SerTestHelper;
+import org.joda.beans.test.BeanAssert;
+import org.joda.collect.grid.DenseGrid;
+import org.joda.collect.grid.SparseGrid;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+import com.google.common.io.Resources;
+
+/**
+ * Test property roundtrip using binary.
+ */
+class TestSerializePackedBin {
+
+    @Test
+    void test_writeAddress() throws IOException {
+        var bean = SerTestHelper.testAddress();
+
+        var bytes = JodaBeanSer.PRETTY.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/Address1.packbinstr");
+
+        var parsed = (Address) JodaBeanSer.PRETTY.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeImmAddress() throws IOException {
+        var bean = SerTestHelper.testImmAddress(false);
+        var bytes = JodaBeanSer.PRETTY.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmAddress1.packbinstr");
+
+        var parsed = (ImmAddress) JodaBeanSer.PRETTY.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeImmAddressCached() throws IOException {
+        var bean = SerTestHelper.testImmAddress(false);
+        var bytes = JodaBeanSer.PRETTY.withBeanValueClasses(Set.of(ImmPerson.class)).binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmAddressCached1.packbinstr");
+
+        var parsed = (ImmAddress) JodaBeanSer.PRETTY.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeImmOptional() throws IOException {
+        var bean = SerTestHelper.testImmOptional();
+        var bytes = JodaBeanSer.PRETTY.withIncludeDerived(true).binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmOptional1.packbinstr");
+
+        var parsed = (ImmOptional) JodaBeanSer.PRETTY.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeImmArrays() throws IOException {
+        var bean = ImmArrays.of(
+                new int[] {1, 3, 2},
+                new long[] {1, 4, 3},
+                new double[] {1.1, 2.2, 3.3},
+                new boolean[] {true, false},
+                new int[][] {{1, 2}, {2}, {}},
+                new boolean[][] {{true, false}, {false}, {}});
+        var bytes = JodaBeanSer.PRETTY.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/ImmArrays1.packbinstr");
+
+        var parsed = JodaBeanSer.PRETTY.binReader().read(bytes, ImmArrays.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeCollections() throws IOException {
+        var bean = SerTestHelper.testCollections(true);
+        var bytes = JodaBeanSer.PRETTY.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+        assertEqualsSerialization(bytes, "/org/joda/beans/ser/Collections1.packbinstr");
+
+        @SuppressWarnings("unchecked")
+        var parsed = (ImmGuava<String>) JodaBeanSer.PRETTY.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    private static void assertEqualsSerialization(byte[] actualBytes, String expectedResource) throws IOException {
+        var url = TestSerializePackedBin.class.getResource(expectedResource);
+        var expected = Resources.asCharSource(url, StandardCharsets.UTF_8).read();
+        var actual = JodaBeanBinReader.visualize(actualBytes);
+        assertThat(actual.trim().replace(lineSeparator(), "\n")).isEqualTo(expected.trim().replace(lineSeparator(), "\n"));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_writeJodaConvertInterface() {
+        var bean = SerTestHelper.testGenericInterfaces();
+
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeIntermediateInterface() {
+        var bean = SerTestHelper.testIntermediateInterfaces();
+
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmKeyList.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_writeJodaConvert() {
+        // immutable bean that is serialized as joda convert
+        var bean = ImmNamedKey.of("name");
+
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean);
+//        System.out.println(JodaBeanBinReader.visualize(bytes));
+
+        var parsed = (ImmNamedKey) JodaBeanSer.COMPACT.binReader().read(bytes);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    void test_readWrite_primitives() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(6);
+        out.writeString("tru");
+        out.writeBoolean(true);
+        out.writeString("fal");
+        out.writeBoolean(false);
+        out.writeString("byt");
+        out.writeByte((byte) 1);
+        out.writeString("sht");
+        out.writeShort((short) 2);
+        out.writeString("flt");
+        out.writeFloat(1.2f);
+        out.writeString("dbl");
+        out.writeDouble(1.8d);
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("tru", Boolean.TRUE);
+        bean.set("fal", Boolean.FALSE);
+        bean.set("byt", Byte.valueOf((byte) 1));
+        bean.set("sht", Short.valueOf((short) 2));
+        bean.set("flt", Float.valueOf(1.2f));
+        bean.set("dbl", Double.valueOf(1.8d));
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_primitiveTypeChanged() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("a");
+        out.writeInt(6);
+        out.writeString("b");
+        out.writeLong(5);
+        var bytes = baos.toByteArray();
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmDoubleFloat.class);
+        assertThat(parsed.getA()).isCloseTo(6, offset(1e-10));
+        assertThat(parsed.getB()).isCloseTo(5, offset(1e-10));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_readWrite_booleanAsObject() throws Throwable {
+        assertValueSerializesAsObject(Boolean.TRUE, BeanPack.TRUE, out -> {});
+        assertValueSerializesAsObject(Boolean.FALSE, BeanPack.FALSE, out -> {});
+    }
+
+    @Test
+    void test_readWrite_charAsObject() throws Throwable {
+        assertValueSerializesAsObject(Character.MAX_VALUE, CHAR_16, out -> out.writeChar(Character.MAX_VALUE));
+        assertValueSerializesAsObject(Character.MIN_VALUE, CHAR_16, out -> out.writeChar(Character.MIN_VALUE));
+    }
+
+    @Test
+    void test_readWrite_byteAsObject() throws Throwable {
+        assertValueSerializesAsObject(Byte.MAX_VALUE, BYTE_8, out -> out.writeByte(Byte.MAX_VALUE));
+        assertValueSerializesAsObject(Byte.MIN_VALUE, BYTE_8, out -> out.writeByte(Byte.MIN_VALUE));
+    }
+
+    @Test
+    void test_readWrite_shortAsObject() throws Throwable {
+        assertValueSerializesAsObject(Short.MAX_VALUE, SHORT_16, out -> out.writeShort(Short.MAX_VALUE));
+        assertValueSerializesAsObject(Short.MIN_VALUE, SHORT_16, out -> out.writeShort(Short.MIN_VALUE));
+    }
+
+    @Test
+    void test_readWrite_intAsObject() throws Throwable {
+        assertValueSerializesAsObject(127, 127, out -> {});
+        assertValueSerializesAsObject(0, 0, out -> {});
+        assertValueSerializesAsObject(-16, -16, out -> {});
+        assertValueSerializesAsObject(-17, INT_16, out -> out.writeShort(-17));
+        assertValueSerializesAsObject(-128, INT_16, out -> out.writeShort(-128));
+        assertValueSerializesAsObject((int) Short.MAX_VALUE, INT_16, out -> out.writeShort(Short.MAX_VALUE));
+        assertValueSerializesAsObject((int) Short.MIN_VALUE, INT_16, out -> out.writeShort(Short.MIN_VALUE));
+        assertValueSerializesAsObject(Integer.MAX_VALUE, INT_32, out -> out.writeInt(Integer.MAX_VALUE));
+        assertValueSerializesAsObject(Integer.MIN_VALUE, INT_32, out -> out.writeInt(Integer.MIN_VALUE));
+    }
+
+    @Test
+    void test_readWrite_longAsObject() throws Throwable {
+        assertValueSerializesAsObject(127L, LONG_8, out -> out.writeByte(127));
+        assertValueSerializesAsObject(0L, LONG_8, out -> out.writeByte(0));
+        assertValueSerializesAsObject(-128L, LONG_8, out -> out.writeByte(-128));
+        assertValueSerializesAsObject((long) Short.MAX_VALUE, LONG_16, out -> out.writeShort(Short.MAX_VALUE));
+        assertValueSerializesAsObject((long) Short.MIN_VALUE, LONG_16, out -> out.writeShort(Short.MIN_VALUE));
+        assertValueSerializesAsObject((long) Integer.MAX_VALUE, LONG_32, out -> out.writeInt(Integer.MAX_VALUE));
+        assertValueSerializesAsObject((long) Integer.MIN_VALUE, LONG_32, out -> out.writeInt(Integer.MIN_VALUE));
+        assertValueSerializesAsObject(Long.MAX_VALUE, LONG_64, out -> out.writeLong(Long.MAX_VALUE));
+        assertValueSerializesAsObject(Long.MIN_VALUE, LONG_64, out -> out.writeLong(Long.MIN_VALUE));
+    }
+
+    @Test
+    void test_readWrite_floatAsObject() throws Throwable {
+        assertValueSerializesAsObject(Float.MAX_VALUE, FLOAT_32, out -> out.writeFloat(Float.MAX_VALUE));
+        assertValueSerializesAsObject(Float.MIN_VALUE, FLOAT_32, out -> out.writeFloat(Float.MIN_VALUE));
+        assertValueSerializesAsObject(Float.NaN, FLOAT_32, out -> out.writeFloat(Float.NaN));
+        assertValueSerializesAsObject(Float.POSITIVE_INFINITY, FLOAT_32, out -> out.writeFloat(Float.POSITIVE_INFINITY));
+        assertValueSerializesAsObject(Float.NEGATIVE_INFINITY, FLOAT_32, out -> out.writeFloat(Float.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    void test_readWrite_doubleAsObject() throws Throwable {
+        assertValueSerializesAsObject(0d, DOUBLE_INT_8, out -> out.writeByte(0));
+        assertValueSerializesAsObject((double) 127, DOUBLE_INT_8, out -> out.writeByte(127));
+        assertValueSerializesAsObject((double) -1, DOUBLE_INT_8, out -> out.writeByte(-1));
+        assertValueSerializesAsObject((double) -128, DOUBLE_INT_8, out -> out.writeByte(-128));
+
+        assertValueSerializesAsObject(-0d, DOUBLE_64, out -> out.writeDouble(-0f));
+        assertValueSerializesAsObject(1.1d, DOUBLE_64, out -> out.writeDouble(1.1d));
+        assertValueSerializesAsObject(Double.MAX_VALUE, DOUBLE_64, out -> out.writeDouble(Double.MAX_VALUE));
+        assertValueSerializesAsObject(Double.MIN_VALUE, DOUBLE_64, out -> out.writeDouble(Double.MIN_VALUE));
+        assertValueSerializesAsObject(Double.NaN, DOUBLE_64, out -> out.writeDouble(Double.NaN));
+        assertValueSerializesAsObject(Double.POSITIVE_INFINITY, DOUBLE_64, out -> out.writeDouble(Double.POSITIVE_INFINITY));
+        assertValueSerializesAsObject(Double.NEGATIVE_INFINITY, DOUBLE_64, out -> out.writeDouble(Double.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    void test_readWrite_dateAsObject() throws Throwable {
+        assertValueSerializesAsObject(LocalDate.of(2024, 6, 1), DATE_PACKED, out -> out.writeShort((short) ((24 * 12 + 5 << 5) + 1)));
+        assertValueSerializesAsObject(LocalDate.of(2000, 1, 1), DATE_PACKED, out -> out.writeShort((short) ((0 * 12 + 0 << 5) + 1)));
+        assertValueSerializesAsObject(LocalDate.of(2169, 12, 31), DATE_PACKED, out -> out.writeShort((short) ((169 * 12 + 11 << 5) + 31)));
+        assertValueSerializesAsObject(LocalDate.of(2170, 1, 1), DATE, out -> {
+            out.writeByte((byte) 0);
+            out.writeInt((2170 << 9) + (1 << 5) + 1);
+        });
+        assertValueSerializesAsObject(LocalDate.of(1999, 12, 31), DATE, out -> {
+            out.writeByte((byte) 0);
+            out.writeInt((1999 << 9) + (12 << 5) + 31);
+        });
+        assertValueSerializesAsObject(LocalDate.MAX, DATE, out -> {
+            out.writeByte((byte) (999999999 >> 23));
+            out.writeInt((999999999 << 9) + (12 << 5) + 31);
+        });
+        assertValueSerializesAsObject(LocalDate.MIN, DATE, out -> {
+            out.writeByte((byte) (-999999999 >> 23));
+            out.writeInt((-999999999 << 9) + (1 << 5) + 1);
+        });
+    }
+
+    @Test
+    void test_readWrite_timeAsObject() throws Throwable {
+        assertValueSerializesAsObject(LocalTime.MAX, TIME, out -> {
+            out.writeShort((short) (LocalTime.MAX.toNanoOfDay() >> 32));
+            out.writeInt((int) LocalTime.MAX.toNanoOfDay());
+        });
+        assertValueSerializesAsObject(LocalTime.MIN, TIME, out -> {
+            out.writeShort((byte) 0);
+            out.writeInt(0);
+        });
+    }
+
+    @Test
+    void test_readWrite_instantAsObject() throws Throwable {
+        assertValueSerializesAsObject(Instant.MAX, INSTANT, out -> {
+            out.writeLong(Instant.MAX.getEpochSecond());
+            out.writeInt(Instant.MAX.getNano());
+        });
+        assertValueSerializesAsObject(Instant.EPOCH, INSTANT, out -> {
+            out.writeLong(Instant.EPOCH.getEpochSecond());
+            out.writeInt(Instant.EPOCH.getNano());
+        });
+        assertValueSerializesAsObject(Instant.MIN, INSTANT, out -> {
+            out.writeLong(Instant.MIN.getEpochSecond());
+            out.writeInt(Instant.MIN.getNano());
+        });
+    }
+
+    @Test
+    void test_readWrite_durationAsObject() throws Throwable {
+        assertValueSerializesAsObject(Duration.ofSeconds(Long.MAX_VALUE, 999_999_999), DURATION, out -> {
+            out.writeLong(Long.MAX_VALUE);
+            out.writeInt(999_999_999);
+        });
+        assertValueSerializesAsObject(Duration.ofSeconds(Long.MIN_VALUE), DURATION, out -> {
+            out.writeLong(Long.MIN_VALUE);
+            out.writeInt(0);
+        });
+    }
+
+    @Test
+    void test_readWrite_stringAsObject() throws Throwable {
+        assertValueSerializesAsObject("", MIN_FIX_STR + 0, out -> {});
+        assertValueSerializesAsObject("A", MIN_FIX_STR + 1, out -> out.write("A".getBytes(UTF_8)));
+        assertValueSerializesAsObject("A".repeat(12), MIN_FIX_STR + 12, out -> out.write("A".repeat(12).getBytes(UTF_8)));
+        assertValueSerializesAsObject("A".repeat(40), MIN_FIX_STR + 40, out -> out.write("A".repeat(40).getBytes(UTF_8)));
+        assertValueSerializesAsObject("A".repeat(41), STR_8, out -> {
+            out.writeByte(41);
+            out.write("A".repeat(41).getBytes(UTF_8));
+        });
+        assertValueSerializesAsObject("A".repeat(255), STR_8, out -> {
+            out.writeByte(255);
+            out.write("A".repeat(255).getBytes(UTF_8));
+        });
+    }
+
+    @Test
+    void test_readWrite_byteArrayAsObject() throws Throwable {
+        assertValueSerializesAsObject(new byte[] {}, BIN_8, out -> out.writeByte(0));
+        assertValueSerializesAsObject(new byte[] {5}, BIN_8, out -> {
+            out.writeByte(1);
+            out.writeByte(5);
+        });
+        assertValueSerializesAsObject(new byte[255], BIN_8, out -> {
+            out.writeByte(255);
+            out.write(new byte[255]);
+        });
+        assertValueSerializesAsObject(new byte[256], BIN_16, out -> {
+            out.writeShort(256);
+            out.write(new byte[256]);
+        });
+    }
+
+    @Test
+    void test_readWrite_doubleArrayAsObject() throws Throwable {
+        assertValueSerializesAsObject(new double[] {}, DOUBLE_ARRAY_8, out -> out.writeByte(0));
+        assertValueSerializesAsObject(new double[] {5.23d}, DOUBLE_ARRAY_8, out -> {
+            out.writeByte(1);
+            out.writeDouble(5.23d);
+        });
+        assertValueSerializesAsObject(new double[255], DOUBLE_ARRAY_8, out -> {
+            out.writeByte(255);
+            out.write(new byte[255 * 8]);
+        });
+        assertValueSerializesAsObject(new double[256], DOUBLE_ARRAY_16, out -> {
+            out.writeShort(256);
+            out.write(new byte[256 * 8]);
+        });
+    }
+
+    private static void assertValueSerializesAsObject(Object value, int typeByte, ThrowingConsumer<DataOutputStream> fn) throws Throwable {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        baos.write(typeByte);
+        fn.accept(new DataOutputStream(baos));
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("value", value);
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_readWrite_optionalAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("present");
+        out.writeTypeReference(BeanPack.TYPE_CODE_OPTIONAL);
+        out.writeArrayHeader(1);
+        out.writeInt(6);
+        out.writeString("empty");
+        out.writeTypeReference(BeanPack.TYPE_CODE_OPTIONAL);
+        out.writeArrayHeader(0);
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("present", Optional.of(6));
+        bean.set("empty", Optional.empty());
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_stringArrayAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        out.writeTypeReference(BeanPack.TYPE_CODE_STRING_ARRAY);
+        out.writeArrayHeader(2);
+        out.writeString("A");
+        out.writeString("B");
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("value", new String[] {"A", "B"});
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_objectArrayAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        out.writeTypeReference(BeanPack.TYPE_CODE_OBJECT_ARRAY);
+        out.writeArrayHeader(2);
+        out.writeString("A");
+        out.writeInt(6);
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("value", new Object[] {"A", 6});
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_intArrayAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        out.writeTypeName("int[]");
+        out.writeArrayHeader(2);
+        out.writeInt(4);
+        out.writeInt(6);
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("value", new int[] {4, 6});
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_readWrite_beanValueClass() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(3);
+        out.writeString("value1");
+        out.writeValueDefinitionHeader();
+        out.writeTypeName(ImmKey.class.getName());
+        out.writeBeanDefinitionHeader(1);
+        out.writeString("name");
+        out.writeString("A");
+        out.writeString("value2");
+        out.writeValueDefinitionHeader();
+        out.writeTypeReference(0);
+        out.writeArrayHeader(1);
+        out.writeString("B");
+        out.writeString("value3");
+        out.writeValueReference(2);
+        var expected = baos.toByteArray();
+
+        var bean = new FlexiBean();
+        bean.set("value1", ImmKey.builder().name("A").build());
+        bean.set("value2", ImmKey.builder().name("B").build());
+        bean.set("value3", ImmKey.builder().name("A").build());
+        var bytes = JodaBeanSer.COMPACT.withBeanValueClasses(Set.of(ImmKey.class)).binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+        assertThat(parsed.get("value1")).isSameAs(parsed.get("value3"));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_readWrite_sparseGridAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        out.writeTypeReference(TYPE_CODE_GRID);
+        out.writeArrayHeader(3);
+        out.writeInt(4);
+        out.writeInt(2);
+        out.writeArrayHeader(6);
+        out.writeInt(0);
+        out.writeInt(1);
+        out.writeString("A");
+        out.writeInt(1);
+        out.writeInt(0);
+        out.writeString("B");
+        var expected = baos.toByteArray();
+
+        var grid = SparseGrid.create(4, 2);
+        grid.put(0, 1, "A");
+        grid.put(1, 0, "B");
+        var bean = new FlexiBean();
+        bean.set("value", grid);
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_denseGridAsObject() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString("value");
+        out.writeTypeReference(TYPE_CODE_GRID);
+        out.writeArrayHeader(3);
+        out.writeInt(-2);
+        out.writeInt(2);
+        out.writeArrayHeader(4);
+        out.writeNull();
+        out.writeString("A");
+        out.writeString("B");
+        out.writeNull();
+        var expected = baos.toByteArray();
+
+        var grid = DenseGrid.create(2, 2);
+        grid.put(0, 1, "A");
+        grid.put(1, 0, "B");
+        var bean = new FlexiBean();
+        bean.set("value", grid);
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_read_typeConvertToDouble() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(126);
+        assertIntegralConvert(bean, "valueDouble", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueDouble", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueDouble", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueDouble", out -> out.writeByte((byte) 126));
+    }
+
+    @Test
+    void test_read_typeConvertToFloat() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueFloat(126);
+        assertIntegralConvert(bean, "valueFloat", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueFloat", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueFloat", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueFloat", out -> out.writeByte((byte) 126));
+    }
+
+    @Test
+    void test_read_typeConvertToLong() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueLong(126);
+        assertIntegralConvert(bean, "valueLong", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueLong", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueLong", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueLong", out -> out.writeByte((byte) 126));
+    }
+
+    @Test
+    void test_read_typeConvertToInt() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueInt(126);
+        assertIntegralConvert(bean, "valueInt", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueInt", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueInt", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueInt", out -> out.writeByte((byte) 126));
+        assertIntegralConvertBad("valueInt", out -> out.writeLong(((long) Integer.MAX_VALUE) + 1));
+        assertIntegralConvertBad("valueInt", out -> out.writeLong(((long) Integer.MIN_VALUE) - 1));
+    }
+
+    @Test
+    void test_read_typeConvertToShort() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueShort((short) 126);
+        assertIntegralConvert(bean, "valueShort", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueShort", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueShort", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueShort", out -> out.writeByte((byte) 126));
+        assertIntegralConvertBad("valueShort", out -> out.writeInt(Short.MAX_VALUE + 1));
+        assertIntegralConvertBad("valueShort", out -> out.writeInt(Short.MIN_VALUE - 1));
+        assertIntegralConvertBad("valueShort", out -> out.writeLong(((long) Short.MAX_VALUE) + 1));
+        assertIntegralConvertBad("valueShort", out -> out.writeLong(((long) Short.MIN_VALUE) - 1));
+    }
+
+    @Test
+    void test_read_typeConvertToByte() throws Throwable {
+        var bean = new PrimitiveBean();
+        bean.setValueByte((byte) 126);
+        assertIntegralConvert(bean, "valueByte", out -> out.writeLong(126));
+        assertIntegralConvert(bean, "valueByte", out -> out.writeInt(126));
+        assertIntegralConvert(bean, "valueByte", out -> out.writeShort((short) 126));
+        assertIntegralConvert(bean, "valueByte", out -> out.writeByte((byte) 126));
+        assertIntegralConvertBad("valueByte", out -> out.writeLong(128));
+        assertIntegralConvertBad("valueByte", out -> out.writeLong(-129));
+        assertIntegralConvertBad("valueByte", out -> out.writeInt(128));
+        assertIntegralConvertBad("valueByte", out -> out.writeInt(-129));
+        assertIntegralConvertBad("valueByte", out -> out.writeShort((short) 128));
+        assertIntegralConvertBad("valueByte", out -> out.writeShort((short) -129));
+    }
+
+    private static void assertIntegralConvert(PrimitiveBean bean, String fieldName, ThrowingConsumer<BeanPackOutput> outFn)
+            throws Throwable {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString(fieldName);
+        outFn.accept(out);
+        BeanAssert.assertBeanEquals(bean, JodaBeanSer.COMPACT.binReader().read(baos.toByteArray(), PrimitiveBean.class));
+    }
+
+    private static void assertIntegralConvertBad(String fieldName, ThrowingConsumer<BeanPackOutput> outFn) throws Throwable {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(1);
+        out.writeString(fieldName);
+        outFn.accept(out);
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(baos.toByteArray(), PrimitiveBean.class));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_read_beanProperty_typeDefinitionInRemovedSubTree_explicitPropertyType() throws Throwable {
+        var bean = new Pair();
+        bean.setFirst(RiskLevel.HIGH);
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#removed' of type TupleFinal
+        out.writeString("removed");
+        out.writeTypeName(TupleFinal.class.getName());  // removed property defined with explicit type
+        out.writeMapHeader(1);
+        out.writeString("first");
+        out.writeTypeName(RiskLevel.class.getName());
+        out.writeString("LOW");
+        // property 'Pair#first' of type RiskLevel
+        out.writeString("first");
+        out.writeValueDefinitionHeader();
+        out.writeTypeReference(1);
+        out.writeString(RiskLevel.HIGH.name());
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    @Test
+    void test_read_beanProperty_typeDefinitionInRemovedSubTree_inferredPropertyTypeForBeanInMapFormat() throws Throwable {
+        var bean = new Pair();
+        bean.setFirst(RiskLevel.HIGH);
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#removed' where the removed property was used to infer the type
+        out.writeString("removed");
+        out.writeMapHeader(1);
+        out.writeString("first");
+        out.writeTypeName(RiskLevel.class.getName());
+        out.writeString("LOW");
+        // property 'Pair#first' of type RiskLevel
+        out.writeString("first");
+        out.writeValueDefinitionHeader();
+        out.writeTypeReference(0);
+        out.writeString(RiskLevel.HIGH.name());
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    @Test
+    void test_read_beanProperty_typeDefinitionInRemovedSubTree_inferredPropertyTypeForBeanInArrayFormat() throws Throwable {
+        var bean = new Pair();
+        bean.setFirst(RiskLevel.HIGH);
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#removed' where the removed property was used to infer the type
+        out.writeString("removed");
+        out.writeArrayHeader(1);  // note that in reality there would have been a bean definition somewhere
+        out.writeTypeName(RiskLevel.class.getName());
+        out.writeString("LOW");
+        // property 'Pair#first' of type RiskLevel
+        out.writeString("first");
+        out.writeValueDefinitionHeader();
+        out.writeTypeReference(0);
+        out.writeString(RiskLevel.HIGH.name());
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    @Test
+    void test_read_beanProperty_typeDefinitionInRemovedSubTree_typeNoLongerExistsButIsNotReferenced() throws Throwable {
+        var bean = new Pair();
+        bean.setFirst(RiskLevel.HIGH);
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#removed' where the removed property was used to infer the type
+        out.writeString("removed");
+        out.writeArrayHeader(1);  // note that in reality there would have been a bean definition somewhere
+        out.writeTypeName("my.BadType");
+        out.writeString("LOW");
+        // property 'Pair#first' of type RiskLevel
+        out.writeString("first");
+        out.writeValueDefinitionHeader();
+        out.writeTypeName(RiskLevel.class.getName());
+        out.writeString(RiskLevel.HIGH.name());
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    @Test
+    void test_read_beanProperty_beanAndValueDefinitionInRemovedSubTree() throws Throwable {
+        var bean = new Pair();
+        var subPair = new Pair();
+        bean.setFirst(subPair);
+        subPair.setFirst(2.5d);
+        subPair.setSecond(1.5d);
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#removed'
+        out.writeString("removed");
+        out.writeTypeName(Pair.class.getName());
+        out.writeBeanDefinitionHeader(2);
+        out.writeString("first");
+        out.writeString("second");
+        out.writeValueDefinitionHeader();
+        out.writeDouble(1.5d);
+        out.writeValueDefinitionHeader();
+        out.writeDouble(2.5d);
+        // property 'Pair#first' of type Pair
+        out.writeString("first");
+        out.writeTypeReference(0);
+        out.writeArrayHeader(2);
+        out.writeValueReference(4);
+        out.writeValueReference(3);
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_read_arrayMultidimensional() throws Throwable {
+        var bean = new Pair();
+        bean.setFirst(new String[][] {{"1", "2"}, {"3"}});
+        bean.setSecond(new Number[][][] {{{1}, {2.5}}, {{3}}});
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        // property 'Pair#first'
+        out.writeString("first");
+        out.writeTypeName("String[][]");
+        out.writeArrayHeader(2);
+        out.writeArrayHeader(2);
+        out.writeString("1");
+        out.writeString("2");
+        out.writeArrayHeader(1);
+        out.writeString("3");
+        // property 'Pair#second'
+        out.writeString("second");
+        out.writeTypeName("java.lang.Number[][][]");
+        out.writeArrayHeader(2);
+        out.writeArrayHeader(2);
+        out.writeArrayHeader(1);
+        out.writeInt(1);
+        out.writeArrayHeader(1);
+        out.writeDouble(2.5d);
+        out.writeArrayHeader(1);
+        out.writeArrayHeader(1);
+        out.writeInt(3);
+        var ser = JodaBeanSer.COMPACT.withDeserializers(SerDeserializers.LENIENT);
+        BeanAssert.assertBeanEquals(bean, ser.binReader().read(baos.toByteArray(), Pair.class));
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_read_optionalTypeToDefaulted() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeString("");
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, ImmDefault.class);
+        assertThat(parsed.getValue()).isEqualTo("Defaulted");
+    }
+
+    @Test
+    void test_readWriteJodaConvertWrapper() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("bean");
+        out.writeValueDefinitionHeader();
+        out.writeTypeName(JodaConvertBean.class.getName());
+        out.writeString("Hello:9");
+        out.writeString("description");
+        out.writeString("Weird");
+        var expected = baos.toByteArray();
+
+        var wrapper = new JodaConvertWrapper();
+        var bean = new JodaConvertBean("Hello:9");
+        wrapper.setBean(bean);
+        wrapper.setDescription("Weird");
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(wrapper, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertWrapper.class);
+        BeanAssert.assertBeanEquals(wrapper, parsed);
+    }
+
+    @Test
+    void test_readWriteJodaConvertBean() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("base");
+        out.writeString("Hello");
+        out.writeString("extra");
+        out.writeInt(9);
+        var expected = baos.toByteArray();
+
+        var bean = new JodaConvertBean("Hello:9");
+        var bytes = JodaBeanSer.COMPACT.binWriter(PACKED).write(bean, false);
+        assertThat(bytes).isEqualTo(expected);
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    void test_read_JodaConvertWrapper_beanNotJodaConvertAndNoDefinition() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("bean");
+        out.writeMapHeader(2);
+        out.writeString("base");
+        out.writeString("Hello");
+        out.writeString("extra");
+        out.writeInt(9);
+        out.writeString("description");
+        out.writeString("Weird");
+        var bytes = baos.toByteArray();
+
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertWrapper.class);
+        var wrapper = new JodaConvertWrapper();
+        var bean = new JodaConvertBean("Hello:9");
+        wrapper.setBean(bean);
+        wrapper.setDescription("Weird");
+        BeanAssert.assertBeanEquals(wrapper, parsed);
+    }
+
+    @Test
+    void test_read_JodaConvertWrapper_beanJodaConvert() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(2);
+        out.writeString("bean");
+        out.writeString("Hello:9");
+        out.writeString("description");
+        out.writeString("Weird");
+        var bytes = baos.toByteArray();
+
+        var parsed = JodaBeanSer.COMPACT.binReader().read(bytes, JodaConvertWrapper.class);
+        var wrapper = new JodaConvertWrapper();
+        var bean = new JodaConvertBean("Hello:9");
+        wrapper.setBean(bean);
+        wrapper.setDescription("Weird");
+        BeanAssert.assertBeanEquals(wrapper, parsed);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    void test_read_invalidFormat_sizeOneArrayAtRoot() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(1);
+        out.writeInt(3);
+        var bytes = baos.toByteArray();
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class));
+    }
+
+    @Test
+    void test_read_wrongVersion() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(0);
+        out.writeNull();
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class));
+    }
+
+    @Test
+    void test_read_rootTypeNotSpecified_FlexiBean() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+        assertThatNoException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class));
+    }
+
+    @Test
+    void test_read_rootTypeNotSpecified_Bean() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, Bean.class));
+    }
+
+    @Test
+    void test_read_rootTypeValid_Bean() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeTypeName(FlexiBean.class.getName());
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+        assertThatNoException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, Bean.class));
+    }
+
+    @Test
+    void test_read_rootTypeInvalid_Bean() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeTypeName(String.class.getName());
+        out.writeMapHeader(0);
+        var bytes = baos.toByteArray();
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, Bean.class));
+    }
+
+    @Test
+    void test_read_rootTypeInvalid_incompatible() throws IOException {
+        var baos = new ByteArrayOutputStream();
+        var out = new BeanPackOutput(baos);
+        out.writeArrayHeader(3);
+        out.writeInt(3);
+        out.writeNull();
+        out.writeTypeName(Company.class.getName());
+        var bytes = baos.toByteArray();
+        assertThatRuntimeException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.binReader().read(bytes, FlexiBean.class));
+    }
+}

--- a/src/test/resources/org/joda/beans/ser/Address1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/Address1.packbinstr
@@ -1,0 +1,94 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type Address
+  bean (4)
+  - str 'number'
+  - str 'street'
+  - str 'city'
+  - str 'owner'
+  - int 251
+  - str 'Big Road'
+  - str 'London & Capital of the World <!>'
+  - @type Person
+    bean (8)
+    - str 'forename'
+    - str 'surname'
+    - str 'numberOfCars'
+    - str 'addressList'
+    - str 'otherAddressMap'
+    - str 'addressesList'
+    - str 'mainAddress'
+    - str 'extensions'
+    - str 'Etienne'
+    - str 'Colebourne'
+    - int 0
+    - arr (3)
+      - arr (4)
+        - int 65432
+        - ref 5 'Big Road'
+        - str 'Bigton'
+        - null
+      - null
+      - @type CompanyAddress
+        bean (5)
+        - ref 1 'number'
+        - ref 2 'street'
+        - ref 3 'city'
+        - ref 4 'owner'
+        - str 'companyName'
+        - int 185
+        - str 'Park Street'
+        - str 'London'
+        - null
+        - str 'OpenGamma'
+    - map (3)
+      = str 'other'
+        null
+      = str 'work'
+        @typeref 2 CompanyAddress
+        arr (5)
+        - int 185
+        - ref 19 'Park Street'
+        - ref 20 'London'
+        - null
+        - ref 21 'OpenGamma'
+      = str 'home'
+        arr (4)
+        - int 65432
+        - ref 5 'Big Road'
+        - ref 17 'Bigton'
+        - null
+    - arr (1)
+      - arr (2)
+        - arr (4)
+          - int 65432
+          - ref 5 'Big Road'
+          - ref 17 'Bigton'
+          - null
+        - @typeref 2 CompanyAddress
+          arr (5)
+          - int 185
+          - ref 19 'Park Street'
+          - ref 20 'London'
+          - null
+          - ref 21 'OpenGamma'
+    - @typeref 2 CompanyAddress
+      arr (5)
+      - int 185
+      - ref 19 'Park Street'
+      - ref 20 'London'
+      - null
+      - ref 21 'OpenGamma'
+    - map (4)
+      = str 'interests'
+        str 'joda'
+      = str 'conferenceCount'
+        int 21
+      = str 'quality'
+        chr B
+      = str 'company'
+        @type Company
+        bean (1)
+        - ref 18 'companyName'
+        - ref 21 'OpenGamma'

--- a/src/test/resources/org/joda/beans/ser/Collections1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/Collections1.packbinstr
@@ -1,0 +1,169 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type ImmGuava
+  bean (35)
+  - str 'collection'
+  - str 'list'
+  - str 'set'
+  - str 'sortedSet'
+  - str 'map'
+  - str 'sortedMap'
+  - str 'biMap'
+  - str 'multimap'
+  - str 'listMultimap'
+  - str 'setMultimap'
+  - str 'multiset'
+  - str 'sortedMultiset'
+  - str 'collectionInterface'
+  - str 'listInterface'
+  - str 'setInterface'
+  - str 'sortedSetInterface'
+  - str 'mapInterface'
+  - str 'sortedMapInterface'
+  - str 'biMapInterface'
+  - str 'multimapInterface'
+  - str 'listMultimapInterface'
+  - str 'setMultimapInterface'
+  - str 'multisetInterface'
+  - str 'sortedMultisetInterface'
+  - str 'listWildExtendsT'
+  - str 'listWildExtendsNumber'
+  - str 'listWildExtendsComparable'
+  - str 'setWildExtendsT'
+  - str 'setWildExtendsNumber'
+  - str 'setWildExtendsComparable'
+  - str 'listWildBuilder1'
+  - str 'listWildBuilder2'
+  - str 'mapWildBuilder1'
+  - str 'mapWildKey'
+  - str 'table'
+  - arr (0)
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (3)
+    = str 'A'
+      int 1
+    = str 'B'
+      int 2
+    = str 'C'
+      int 3
+  - map (0)
+  - arr (0)
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - arr (2)
+    - str 'A'
+    - str 'B'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      str 'AA'
+    = str 'B'
+      str 'BB'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (2)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'C'
+    = str 'B'
+      arr (1)
+      - str 'D'
+  - map (0)
+  - map (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - arr (0)
+  - map (0)
+  - map (0)
+  - map (2)
+    = str 'A'
+      map (2)
+      = int 1
+        str 'B'
+      = int 2
+        str 'C'
+    = str 'B'
+      map (1)
+      = int 3
+        str 'D'

--- a/src/test/resources/org/joda/beans/ser/ImmAddress1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/ImmAddress1.packbinstr
@@ -1,0 +1,378 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type ImmAddress
+  bean (26)
+  - str 'number'
+  - str 'street'
+  - str 'city'
+  - str 'abstractNumber'
+  - str 'data'
+  - str 'array2d'
+  - str 'owner'
+  - str 'object1'
+  - str 'object2'
+  - str 'risk'
+  - str 'riskLevel'
+  - str 'riskLevels'
+  - str 'serializable'
+  - str 'objectInMap'
+  - str 'listInMap'
+  - str 'listNumericInMap'
+  - str 'listInListInMap'
+  - str 'objectListInListInMap'
+  - str 'mapInMap'
+  - str 'simpleTable'
+  - str 'compoundTable'
+  - str 'sparseGrid'
+  - str 'denseGrid'
+  - str 'beanBeanMap'
+  - str 'doubleVector'
+  - str 'matrix'
+  - int 185
+  - str 'Park Street'
+  - str 'London & Capital of the World <!>
+'
+  - sht 89
+  - null
+  - arr (3)
+    - arr (1)
+      - str 'a'
+    - arr (0)
+    - arr (2)
+      - str 'b'
+      - str 'c'
+  - @type ImmPerson
+    bean (10)
+    - str 'forename'
+    - str 'surname'
+    - str 'numberOfCars'
+    - str 'dateOfBirth'
+    - str 'middleNames'
+    - str 'addressList'
+    - str 'otherAddressMap'
+    - str 'addressesList'
+    - str 'mainAddress'
+    - str 'codeCounts'
+    - str 'Etienne'
+    - str 'Colebourne'
+    - int 1
+    - null
+    - arr (2)
+      - str 'K'
+      - str 'T'
+    - arr (1)
+      - @type Address
+        bean (4)
+        - ref 1 'number'
+        - ref 2 'street'
+        - ref 3 'city'
+        - ref 7 'owner'
+        - int 0
+        - null
+        - null
+        - null
+    - null
+    - null
+    - null
+    - map (2)
+      = str 'A'
+        int 2
+      = str 'B'
+        int 1
+  - @typeref List
+    arr (3)
+    - str 'a'
+    - str 'b'
+    - str 'c'
+  - @typeref Map
+    map (2)
+    = str 'd'
+      int 1
+    = @value 
+      @type java.util.Currency
+      str 'GBP'
+      int 2
+  - null
+  - null
+  - null
+  - @typeref List
+    arr (3)
+    - str 'a'
+    - str 'b'
+    - str 'c'
+  - map (4)
+    = str 'A'
+      str 'Abba'
+    = str 'B'
+      @typeref Set
+      arr (2)
+      - str 'a'
+      - str 'b'
+    = str 'C'
+      @typeref Set
+      arr (3)
+      - @value 
+        @type Locale
+        str 'fr_CA'
+      - lng 2
+      - @type PrimitiveBean
+        bean (8)
+        - str 'valueLong'
+        - str 'valueInt'
+        - str 'valueShort'
+        - str 'valueByte'
+        - str 'valueDouble'
+        - str 'valueFloat'
+        - str 'valueChar'
+        - str 'valueBoolean'
+        - lng 1
+        - int 2
+        - sht 3
+        - byt 4
+        - dbl 5.0
+        - flt 6.0
+        - chr 7
+        - true
+    = str 'D'
+      @typeref Map
+      map (2)
+      = str 'd'
+        int 1
+      = str 'e'
+        int 2
+  - map (1)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'b'
+  - map (1)
+    = str 'A'
+      arr (3)
+      - int 3
+      - int 2
+      - int 1
+  - map (1)
+    = str 'A'
+      arr (1)
+      - arr (3)
+        - int 3
+        - int 2
+        - int 1
+  - map (2)
+    = str 'A'
+      arr (1)
+      - arr (2)
+        - ref 42 'GBP'
+        - @value 
+          @type java.util.TimeZone
+          str 'Europe/London'
+    = str 'B'
+      arr (1)
+      - arr (3)
+        - ref 45 'fr_CA'
+        - lng 2
+        - @typeref 5 PrimitiveBean
+          arr (8)
+          - lng 1
+          - int 2
+          - sht 3
+          - byt 4
+          - dbl 5.0
+          - flt 6.0
+          - chr 7
+          - true
+  - map (1)
+    = arr (10)
+      - str 'Etiennette'
+      - ref 40 'Colebourne'
+      - int 1
+      - null
+      - arr (0)
+      - null
+      - null
+      - null
+      - null
+      - null
+      map (1)
+      = str 'sibling'
+        arr (10)
+        - str 'Kylie'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+  - map (1)
+    = int 1
+      map (2)
+      = int 1
+        str 'Hello'
+      = int 2
+        str 'There'
+  - map (2)
+    = int 1
+      map (2)
+      = int 1
+        arr (10)
+        - ref 39 'Etienne'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (2)
+          - str 'K'
+          - str 'T'
+        - arr (1)
+          - arr (4)
+            - int 0
+            - null
+            - null
+            - null
+        - null
+        - null
+        - null
+        - map (2)
+          = str 'A'
+            int 2
+          = str 'B'
+            int 1
+      = int 2
+        arr (10)
+        - ref 56 'Etiennette'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+    = int 2
+      map (1)
+      = int 1
+        arr (10)
+        - ref 58 'Kylie'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+  - arr (3)
+    - int 5
+    - int 5
+    - arr (3)
+      - int 1
+      - int 1
+      - arr (10)
+        - ref 58 'Kylie'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+  - arr (3)
+    - int 2
+    - int 3
+    - arr (6)
+      - int 0
+      - int 0
+      - arr (10)
+        - ref 56 'Etiennette'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+      - int 1
+      - int 1
+      - arr (10)
+        - ref 58 'Kylie'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+  - map (1)
+    = arr (10)
+      - ref 56 'Etiennette'
+      - ref 40 'Colebourne'
+      - int 1
+      - null
+      - arr (0)
+      - null
+      - null
+      - null
+      - null
+      - null
+      arr (26)
+      - int 185
+      - ref 27 'Park Street'
+      - str 'London'
+      - null
+      - bin '404142'
+      - null
+      - arr (10)
+        - ref 56 'Etiennette'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+      - @value 
+        @type Risk
+        str 'MEDIUM'
+      - @value 
+        @type RiskPerception
+        str 'LOW'
+      - @value 
+        @typeref 7 Risk
+        ref 64 'LOW'
+      - @value 
+        @typeref 7 Risk
+        str 'HIGH'
+      - arr (2)
+        - ref 66 'LOW'
+        - ref 63 'MEDIUM'
+      - null
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - null
+      - null
+      - null
+      - null
+      - map (0)
+      - null
+      - null
+  - dbl [1.1,2.2,3.3]
+  - arr (2)
+    - dbl [1.1,2.2]
+    - dbl [3.2]

--- a/src/test/resources/org/joda/beans/ser/ImmAddressCached1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/ImmAddressCached1.packbinstr
@@ -1,0 +1,292 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type ImmAddress
+  bean (26)
+  - str 'number'
+  - str 'street'
+  - str 'city'
+  - str 'abstractNumber'
+  - str 'data'
+  - str 'array2d'
+  - str 'owner'
+  - str 'object1'
+  - str 'object2'
+  - str 'risk'
+  - str 'riskLevel'
+  - str 'riskLevels'
+  - str 'serializable'
+  - str 'objectInMap'
+  - str 'listInMap'
+  - str 'listNumericInMap'
+  - str 'listInListInMap'
+  - str 'objectListInListInMap'
+  - str 'mapInMap'
+  - str 'simpleTable'
+  - str 'compoundTable'
+  - str 'sparseGrid'
+  - str 'denseGrid'
+  - str 'beanBeanMap'
+  - str 'doubleVector'
+  - str 'matrix'
+  - int 185
+  - str 'Park Street'
+  - str 'London & Capital of the World <!>
+'
+  - sht 89
+  - null
+  - arr (3)
+    - arr (1)
+      - str 'a'
+    - arr (0)
+    - arr (2)
+      - str 'b'
+      - str 'c'
+  - @value 
+    @type ImmPerson
+    bean (10)
+    - str 'forename'
+    - str 'surname'
+    - str 'numberOfCars'
+    - str 'dateOfBirth'
+    - str 'middleNames'
+    - str 'addressList'
+    - str 'otherAddressMap'
+    - str 'addressesList'
+    - str 'mainAddress'
+    - str 'codeCounts'
+    - str 'Etienne'
+    - str 'Colebourne'
+    - int 1
+    - null
+    - arr (2)
+      - str 'K'
+      - str 'T'
+    - arr (1)
+      - @type Address
+        bean (4)
+        - ref 1 'number'
+        - ref 2 'street'
+        - ref 3 'city'
+        - ref 7 'owner'
+        - int 0
+        - null
+        - null
+        - null
+    - null
+    - null
+    - null
+    - map (2)
+      = str 'A'
+        int 2
+      = str 'B'
+        int 1
+  - @typeref List
+    arr (3)
+    - str 'a'
+    - str 'b'
+    - str 'c'
+  - @typeref Map
+    map (2)
+    = str 'd'
+      int 1
+    = @value 
+      @type java.util.Currency
+      str 'GBP'
+      int 2
+  - null
+  - null
+  - null
+  - @typeref List
+    arr (3)
+    - str 'a'
+    - str 'b'
+    - str 'c'
+  - map (4)
+    = str 'A'
+      str 'Abba'
+    = str 'B'
+      @typeref Set
+      arr (2)
+      - str 'a'
+      - str 'b'
+    = str 'C'
+      @typeref Set
+      arr (3)
+      - @value 
+        @type Locale
+        str 'fr_CA'
+      - lng 2
+      - @type PrimitiveBean
+        bean (8)
+        - str 'valueLong'
+        - str 'valueInt'
+        - str 'valueShort'
+        - str 'valueByte'
+        - str 'valueDouble'
+        - str 'valueFloat'
+        - str 'valueChar'
+        - str 'valueBoolean'
+        - lng 1
+        - int 2
+        - sht 3
+        - byt 4
+        - dbl 5.0
+        - flt 6.0
+        - chr 7
+        - true
+    = str 'D'
+      @typeref Map
+      map (2)
+      = str 'd'
+        int 1
+      = str 'e'
+        int 2
+  - map (1)
+    = str 'A'
+      arr (2)
+      - str 'B'
+      - str 'b'
+  - map (1)
+    = str 'A'
+      arr (3)
+      - int 3
+      - int 2
+      - int 1
+  - map (1)
+    = str 'A'
+      arr (1)
+      - arr (3)
+        - int 3
+        - int 2
+        - int 1
+  - map (2)
+    = str 'A'
+      arr (1)
+      - arr (2)
+        - ref 43 'GBP'
+        - @value 
+          @type java.util.TimeZone
+          str 'Europe/London'
+    = str 'B'
+      arr (1)
+      - arr (3)
+        - ref 46 'fr_CA'
+        - lng 2
+        - @typeref 5 PrimitiveBean
+          arr (8)
+          - lng 1
+          - int 2
+          - sht 3
+          - byt 4
+          - dbl 5.0
+          - flt 6.0
+          - chr 7
+          - true
+  - map (1)
+    = @value 
+      @typeref 1 ImmPerson
+      arr (10)
+      - str 'Etiennette'
+      - ref 40 'Colebourne'
+      - int 1
+      - null
+      - arr (0)
+      - null
+      - null
+      - null
+      - null
+      - null
+      map (1)
+      = str 'sibling'
+        @value 
+        @typeref 1 ImmPerson
+        arr (10)
+        - str 'Kylie'
+        - ref 40 'Colebourne'
+        - int 1
+        - null
+        - arr (0)
+        - null
+        - null
+        - null
+        - null
+        - null
+  - map (1)
+    = int 1
+      map (2)
+      = int 1
+        str 'Hello'
+      = int 2
+        str 'There'
+  - map (2)
+    = int 1
+      map (2)
+      = int 1
+        ref 41 '<bean>'
+      = int 2
+        ref 58 '<bean>'
+    = int 2
+      map (1)
+      = int 1
+        ref 61 '<bean>'
+  - arr (3)
+    - int 5
+    - int 5
+    - arr (3)
+      - int 1
+      - int 1
+      - ref 61 '<bean>'
+  - arr (3)
+    - int 2
+    - int 3
+    - arr (6)
+      - int 0
+      - int 0
+      - ref 58 '<bean>'
+      - int 1
+      - int 1
+      - ref 61 '<bean>'
+  - map (1)
+    = ref 58 '<bean>'
+      arr (26)
+      - int 185
+      - ref 27 'Park Street'
+      - str 'London'
+      - null
+      - bin '404142'
+      - null
+      - ref 58 '<bean>'
+      - @value 
+        @type Risk
+        str 'MEDIUM'
+      - @value 
+        @type RiskPerception
+        str 'LOW'
+      - @value 
+        @typeref 7 Risk
+        ref 67 'LOW'
+      - @value 
+        @typeref 7 Risk
+        str 'HIGH'
+      - arr (2)
+        - ref 69 'LOW'
+        - ref 66 'MEDIUM'
+      - null
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - map (0)
+      - null
+      - null
+      - null
+      - null
+      - map (0)
+      - null
+      - null
+  - dbl [1.1,2.2,3.3]
+  - arr (2)
+    - dbl [1.1,2.2]
+    - dbl [3.2]

--- a/src/test/resources/org/joda/beans/ser/ImmArrays1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/ImmArrays1.packbinstr
@@ -1,0 +1,37 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type ImmArrays
+  bean (6)
+  - str 'intArray'
+  - str 'longArray'
+  - str 'doubleArray'
+  - str 'booleanArray'
+  - str 'intArray2d'
+  - str 'booleanArray2d'
+  - arr (3)
+    - int 1
+    - int 3
+    - int 2
+  - arr (3)
+    - lng 1
+    - lng 4
+    - lng 3
+  - dbl [1.1,2.2,3.3]
+  - arr (2)
+    - true
+    - false
+  - arr (3)
+    - arr (2)
+      - int 1
+      - int 2
+    - arr (1)
+      - int 2
+    - arr (0)
+  - arr (3)
+    - arr (2)
+      - true
+      - false
+    - arr (1)
+      - false
+    - arr (0)

--- a/src/test/resources/org/joda/beans/ser/ImmOptional1.packbinstr
+++ b/src/test/resources/org/joda/beans/ser/ImmOptional1.packbinstr
@@ -1,0 +1,20 @@
+arr (3)
+- int 3
+- str 'org.joda.beans.sample.'
+- @type ImmOptional
+  bean (7)
+  - str 'optString'
+  - str 'optStringEmpty'
+  - str 'optStringGetter'
+  - str 'optLongGetter'
+  - str 'optIntGetter'
+  - str 'optDoubleGetter'
+  - str 'twelve'
+  - arr (1)
+    - str 'A'
+  - arr (0)
+  - null
+  - null
+  - null
+  - null
+  - int 12


### PR DESCRIPTION
* New binary format, with a faster foundation
* Uses dedicated serialization approach inspired by MessagePack
* Setup as v3 binary format
* Allows callers to explicitly reference certain beans
* Specific approach avoids hash code issues with large beans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PACKED` binary format for serialization, enhancing data handling capabilities.
	- Added support for reading and writing various complex data structures, including nested beans and collections.
	- New methods for customizing bean serialization and deserialization processes.

- **Bug Fixes**
	- Improved error handling for invalid binary formats and type mismatches.

- **Tests**
	- Comprehensive unit tests added to validate the serialization and deserialization processes for various bean types and structures.

- **Documentation**
	- Updated serialization formats and structures for `Address`, `Person`, `ImmAddress`, and collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->