### PR TITLE
Minor fixes to serialization

### DIFF
--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
@@ -536,11 +536,13 @@ final class JodaBeanPackedBinWriter {
                 writeArrayTypeDescription(writer, arrayType);
             }
             // write content
-            var handler = JodaBeanPackedBinWriter.LOOKUP.get(arrayType.getComponentType());
+            var arrayComponentType = arrayType.getComponentType();
+            var componentType = ResolvedType.of(arrayComponentType);
+            var handler = JodaBeanPackedBinWriter.LOOKUP.get(arrayComponentType);
             var arrayLength = Array.getLength(array);
             writer.output.writeArrayHeader(arrayLength);
             for (int i = 0; i < arrayLength; i++) {
-                handler.handle(writer, declaredType, propertyName, Array.get(array, i));
+                handler.handle(writer, componentType, propertyName, Array.get(array, i));
             }
         }
 


### PR DESCRIPTION
* Use array component type when serializing array items
* Rename variables and methods
* Use Iterable directly in simple JSON, as size is not needed