### PR TITLE
Unify the JSON writers

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,7 +50,7 @@
         Incompatible change:
         The JSON serialization formats have changed requiring fewer @meta and @type annotations.
         For example, where the type of the collection is Object,
-        previously a String value was explicitly typed as a String, now the type is implcit.
+        previously a String value was explicitly typed as a String, now the type is implicit.
         This is a much more natural JSON format.
         The old format cam still be parsed successfully.
       </action>

--- a/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
+++ b/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
@@ -136,11 +136,11 @@ public class JodaBeanJsonWriter {
     /**
      * The settings to use.
      */
-    private final JodaBeanSer settings;
+    final JodaBeanSer settings;  // CSIGNORE
     /**
      * The outputter.
      */
-    private JsonOutput output;
+    JsonOutput output;  // CSIGNORE
     /**
      * The base package including the trailing dot.
      */
@@ -223,7 +223,7 @@ public class JodaBeanJsonWriter {
 
     //-----------------------------------------------------------------------
     // walk an object, by determining the runtime type
-    private void writeObject(ResolvedType declaredType, String propertyName, Object value) throws IOException {
+    void writeObject(ResolvedType declaredType, String propertyName, Object value) throws IOException {
         if (value == null) {
             output.writeNull();
         } else {
@@ -252,7 +252,7 @@ public class JodaBeanJsonWriter {
     }
 
     // optionally writes the type of the bean
-    private void writeBeanType(ResolvedType declaredType, Bean bean, boolean includeRootType) throws IOException {
+    void writeBeanType(ResolvedType declaredType, Bean bean, boolean includeRootType) throws IOException {
         if (bean.getClass() != declaredType.getRawType()) {
             var typeStr = SerTypeMapper.encodeType(bean.getClass(), settings, basePackage, knownTypes);
             if (includeRootType) {
@@ -277,7 +277,7 @@ public class JodaBeanJsonWriter {
     }
 
     //-------------------------------------------------------------------------
-    private void writeLong(ResolvedType declaredType, Long val) throws IOException {
+    void writeLong(ResolvedType declaredType, Long val) throws IOException {
         if (declaredType.getRawType() == long.class) {
             output.writeLong(val);
         } else {
@@ -289,7 +289,7 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeShort(ResolvedType declaredType, Short val) throws IOException {
+    void writeShort(ResolvedType declaredType, Short val) throws IOException {
         if (declaredType.getRawType() == short.class) {
             output.writeInt(val);
         } else {
@@ -301,7 +301,7 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeByte(ResolvedType declaredType, Byte val) throws IOException {
+    void writeByte(ResolvedType declaredType, Byte val) throws IOException {
         if (declaredType.getRawType() == byte.class) {
             output.writeInt(val);
         } else {
@@ -313,7 +313,7 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeDouble(ResolvedType declaredType, Double val) throws IOException {
+    void writeDouble(ResolvedType declaredType, Double val) throws IOException {
         if (declaredType.getRawType() == double.class || (!Double.isNaN(val) && !Double.isInfinite(val))) {
             output.writeDouble(val);
         } else {
@@ -325,7 +325,7 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeFloat(ResolvedType declaredType, Float val) throws IOException {
+    void writeFloat(ResolvedType declaredType, Float val) throws IOException {
         if (declaredType.getRawType() == float.class) {
             output.writeFloat(val);
         } else {
@@ -337,7 +337,8 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeSimple(ResolvedType declaredType, String propertyName, Object value) throws IOException {
+    // writes a simple type
+    void writeSimple(ResolvedType declaredType, String propertyName, Object value) throws IOException {
         // handle no declared type and subclasses
         Class<?> realType = value.getClass();
         Class<?> effectiveType = declaredType.getRawType();
@@ -363,22 +364,6 @@ public class JodaBeanJsonWriter {
         }
 
         writeJodaConvert(declaredType, propertyName, value);
-//        // long/short/byte/float only processed now to ensure that exact numeric type can be identified
-//        if (realType == Long.class || realType == long.class) {
-//            output.writeLong(((Long) value).longValue());
-//
-//        } else if (realType == Short.class) {
-//            output.writeInt(((Short) value).shortValue());
-//
-//        } else if (realType == Byte.class) {
-//            output.writeInt(((Byte) value).byteValue());
-//
-//        } else if (realType == Float.class) {
-//            output.writeFloat(((Float) value).floatValue());
-//
-//        } else {
-//            writeJodaConvert(declaredType, propertyName, value);
-//        }
 
         // close open map
         if (requiresClose) {
@@ -386,7 +371,8 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeJodaConvert(ResolvedType declaredType, String propertyName, Object value) throws IOException {
+    // writes using Joda-Convert
+    void writeJodaConvert(ResolvedType declaredType, String propertyName, Object value) throws IOException {
         var realType = value.getClass();
         try {
             var converted = settings.getConverter().convertToString(value);
@@ -407,7 +393,7 @@ public class JodaBeanJsonWriter {
     }
 
     // writes a map given map entries, code shared with Multimap
-    private <K, V> void writeMapEntries(
+    <K, V> void writeMapEntries(
             ResolvedType declaredType,
             String propertyName,
             Collection<Map.Entry<K, V>> mapEntries) throws IOException {
@@ -470,12 +456,12 @@ public class JodaBeanJsonWriter {
         output.writeArrayEnd();
     }
 
-    private static IllegalArgumentException invalidNullMapKey(String propertyName) {
+    static IllegalArgumentException invalidNullMapKey(String propertyName) {
         return new IllegalArgumentException(
                 "Unable to write property '" + propertyName + "', map key must not be null");
     }
 
-    private static IllegalArgumentException invalidConvertedNullMapKey(String propertyName) {
+    static IllegalArgumentException invalidConvertedNullMapKey(String propertyName) {
         return new IllegalArgumentException(
                 "Unable to write property '" + propertyName + "', converted map key must not be null");
     }
@@ -483,7 +469,7 @@ public class JodaBeanJsonWriter {
     //-------------------------------------------------------------------------
     // gets the weakened type, which exists for backwards compatibility
     // once the parser can handle ResolvedType this method can, in theory, be removed
-    private static ResolvedType toWeakenedType(ResolvedType base) {
+    static ResolvedType toWeakenedType(ResolvedType base) {
         for (var arg : base.getArguments()) {
             var rawType = arg.getRawType();
             if (LOOKUP.get(rawType).isCollection()) {
@@ -495,17 +481,17 @@ public class JodaBeanJsonWriter {
 
     //-------------------------------------------------------------------------
     // handler for meta types, but with IOException
-    private static interface MetaTypeHandler {
+    static interface MetaTypeHandler {
         public abstract String handle() throws IOException;
     }
 
     // handler for meta type content, but with IOException
-    private static interface ContentHandler {
+    static interface ContentHandler {
         public abstract void handle() throws IOException;
     }
 
     // writes content with a meta type
-    private void writeWithMetaType(ContentHandler contentHandler, MetaTypeHandler metaTypeHandler) throws IOException {
+    void writeWithMetaType(ContentHandler contentHandler, MetaTypeHandler metaTypeHandler) throws IOException {
         var metaTypeName = metaTypeHandler.handle();
         if (metaTypeName != null) {
             output.writeObjectStart();
@@ -518,7 +504,8 @@ public class JodaBeanJsonWriter {
         }
     }
 
-    private void writeWithMetaType(ContentHandler contentHandler, Class<?> cls, ResolvedType declaredType, String metaTypeName)
+    // writes content with a meta type
+    void writeWithMetaType(ContentHandler contentHandler, Class<?> cls, ResolvedType declaredType, String metaTypeName)
             throws IOException {
 
         if (!cls.isAssignableFrom(declaredType.getRawType())) {

--- a/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
+++ b/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
@@ -268,7 +268,7 @@ class TestSerializeJson {
 
     //-------------------------------------------------------------------------
     @Test
-    void test_readWrite_boolean_true() {
+    void test_readWrite_booleanObject_true() {
         var bean = new FlexiBean();
         bean.set("data", Boolean.TRUE);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -290,7 +290,7 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_long() {
+    void test_readWrite_longObject() {
         var bean = new FlexiBean();
         bean.set("data", (long) 6);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -301,7 +301,7 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_short() {
+    void test_readWrite_shortObject() {
         var bean = new FlexiBean();
         bean.set("data", (short) 6);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -312,7 +312,7 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_byte() {
+    void test_readWrite_byteObject() {
         var bean = new FlexiBean();
         bean.set("data", (byte) 6);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -323,7 +323,7 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_float() {
+    void test_readWrite_floatObject() {
         var bean = new FlexiBean();
         bean.set("data", (float) 6);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -334,7 +334,7 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_float_NaN() {
+    void test_readWrite_floatObject_NaN() {
         var bean = new FlexiBean();
         bean.set("data", Float.NaN);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -354,73 +354,6 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_double() {
-        var bean = new FlexiBean();
-        bean.set("data", (double) 6);
-        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
-        assertThat(json)
-                .isEqualTo("{\"@bean\":\"org.joda.beans.impl.flexi.FlexiBean\",\"data\":6.0}");
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_readWrite_double_alternateFormat() {
-        var bean = new FlexiBean();
-        bean.set("data", (double) 6);
-        var json = "{\"@bean\":\"org.joda.beans.impl.flexi.FlexiBean\",\"data\":{\"@type\":\"Double\",\"value\":6.0}}";
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_readWrite_double_NaN() {
-        var bean = new FlexiBean();
-        bean.set("data", Double.NaN);
-        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
-        assertThat(json).isEqualTo(
-                "{\"@bean\":\"org.joda.beans.impl.flexi.FlexiBean\",\"data\":{\"@type\":\"Double\",\"value\":\"NaN\"}}");
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_readWrite_double_Infinity() {
-        var bean = new FlexiBean();
-        bean.set("data", Double.POSITIVE_INFINITY);
-        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
-        assertThat(json).isEqualTo(
-                "{\"@bean\":\"org.joda.beans.impl.flexi.FlexiBean\",\"data\":{\"@type\":\"Double\",\"value\":\"Infinity\"}}");
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_read_double_integer_flexiWithTypeAnnotation() {
-        var bean = new FlexiBean();
-        bean.set("data", Double.valueOf(6));
-        var json = "{\"@bean\":\"org.joda.beans.impl.flexi.FlexiBean\",\"data\":{\"@type\":\"Double\",\"value\":\"6\"}}";
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_read_double_fromInteger() {
-        var bean = new PrimitiveBean();
-        bean.setValueDouble(6d);
-        var json = "{\"@bean\":\"org.joda.beans.sample.PrimitiveBean\",\"valueDouble\":6}";
-        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
-        BeanAssert.assertBeanEquals(bean, parsed);
-    }
-
-    @Test
-    void test_read_double_fromIntegerTooBig() {
-        var json = "{\"@bean\":\"org.joda.beans.sample.PrimitiveBean\",\"valueDouble\":123456789123456789}";
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> JodaBeanSer.COMPACT.jsonReader().read(json));
-    }
-
-    @Test
     void test_read_float_fromInteger() {
         var bean = new PrimitiveBean();
         bean.setValueFloat(6f);
@@ -436,13 +369,133 @@ class TestSerializeJson {
                 .isThrownBy(() -> JodaBeanSer.COMPACT.jsonReader().read(json));
     }
 
+    //-------------------------------------------------------------------------
     @Test
-    void test_read_double_NaN_asNull() {
-        var bean = new PrimitiveBean();
-        bean.setValueDouble(Double.NaN);
-        var json = "{\"@bean\":\"org.joda.beans.sample.PrimitiveBean\",\"valueDouble\":null}";
+    void test_readWrite_doubleObject() {
+        var bean = new FlexiBean();
+        bean.set("data", (double) 6);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":6.0}""");
         var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
         BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_doubleObject_NaN() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.NaN);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":{"@type":"Double","value":"NaN"}}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_doubleObject_PositiveInfinity() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":{"@type":"Double","value":"Infinity"}}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_doubleObject_NegativeInfinity() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":{"@type":"Double","value":"-Infinity"}}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NaN() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"NaN","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_PositiveInfinity() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"-Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_doubleObject_alternateFormat() {
+        var bean = new FlexiBean();
+        bean.set("data", (double) 6);
+        var json = """
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":{"@type":"Double","value":6.0}}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_doubleObject_integer_flexiWithTypeAnnotation() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.valueOf(6));
+        var json = """
+                {"@bean":"org.joda.beans.impl.flexi.FlexiBean","data":{"@type":"Double","value":6}}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_double_NaN_asNull_alternateFormat() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = """
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueDouble":null}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_double_fromInteger() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(6d);
+        var json = """
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueDouble":6}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_double_fromIntegerTooBig() {
+        var json = """
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","data":{"@type":"Double","value":123456789123456789}}""";
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> JodaBeanSer.COMPACT.jsonReader().read(json));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/beans/ser/json/TestSerializeJsonSimple.java
+++ b/src/test/java/org/joda/beans/ser/json/TestSerializeJsonSimple.java
@@ -35,6 +35,7 @@ import org.joda.beans.sample.ImmDoubleFloat;
 import org.joda.beans.sample.ImmGuava;
 import org.joda.beans.sample.ImmOptional;
 import org.joda.beans.sample.Person;
+import org.joda.beans.sample.PrimitiveBean;
 import org.joda.beans.sample.SimpleJson;
 import org.joda.beans.ser.JodaBeanSer;
 import org.joda.beans.ser.SerDeserializers;
@@ -194,6 +195,79 @@ class TestSerializeJsonSimple {
         var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
         assertThat(json).isEqualTo("{\"data\":false}");
         var parsed = JodaBeanSer.COMPACT.simpleJsonReader().read(new StringReader(json), FlexiBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    //-------------------------------------------------------------------------
+    @Test
+    void test_write_doubleObject() {
+        var bean = new FlexiBean();
+        bean.set("data", (double) 6);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"data":6.0}""");
+    }
+
+    @Test
+    void test_write_doubleObject_NaN() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.NaN);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"data":null}""");
+    }
+
+    @Test
+    void test_write_doubleObject_PositiveInfinity() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"data":"Infinity"}""");
+    }
+
+    @Test
+    void test_write_doubleObject_NegativeInfinity() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"data":"-Infinity"}""");
+    }
+
+    @Test
+    void test_readWrite_double_NaN() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":null,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_PositiveInfinity() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"-Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
         BeanAssert.assertBeanEquals(bean, parsed);
     }
 


### PR DESCRIPTION
* Also test doubles more thoroughly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Joda-Beans v3.0.0-RC1

- **New Features**
    - Upgraded to Java SE 21 compatibility
    - Introduced new binary serialisation format
    - Enhanced JSON serialisation support for collections and special numeric values

- **Breaking Changes**
    - Removed deprecated methods
    - Updated serialisation approach for primitive arrays
    - Requires explicit selection of binary format
    - Manual implementation of `equals`, `hashCode`, and `toString` methods now requires specific placement

- **Improvements**
    - Simplified JSON serialisation annotations
    - Better handling of null map keys
    - Improved support for nested class method definitions
    - Enhanced performance and size optimisations

- **Bug Fixes**
    - Corrected `BeanAssert` class messaging for property-level equality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->