### PR TITLE
Control JSON NaN/Infinity

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -54,9 +54,11 @@
         This is a much more natural JSON format.
         The old format cam still be parsed successfully.
       </action>
-      <action dev="jodastephen" type="fix">
-        Fix `BeanAssert` to output the correct message.
-        Previously there was no check for equals at the property level, nor were arrays properly converted to `String`.
+      <action dev="jodastephen" type="update" issue="192">
+        Incompatible change:
+        The simple JSON serialization format now uses a string instead of null for NaN for consistency.
+        The new configuration 'JodaBeanJsonNumberFormat' can be used to control how NaN and Infinity are output.
+        As part of this change, the extended literals from 'The JSON5 Data Interchange Format' can be used if desired.
       </action>
     </release>
     <release version="2.12.0" date="SNAPSHOT" description="v2.12.0">
@@ -65,10 +67,19 @@
         Properties of type 'boolean[]' and 2-dimensional arrays are now cloned by default in immutable beans
         in line with existing behaviour. Cloning is opt-in for mutable beans using new settings on `PropertyDefinition`.
       </action>
+      <action dev="jodastephen" type="fix" issue="424">
+        Potentially incompatible bug fix:
+        Binary and JSON parsers now accept the formats produced by v3.x.
+        Certain edge cases now succeed when previously an exception would have been thrown.
+      </action>
       <action dev="jodastephen" type="fix" issue="405">
         Fix code generation for property names that clash with code generated method parameters.
         Properties named `obj`, `other` or `propertyName` caused problems.
         These are now prefixed by `this` to avoid the clash.
+      </action>
+      <action dev="jodastephen" type="fix">
+        Fix `BeanAssert` to output the correct message.
+        Previously there was no check for equals at the property level, nor were arrays properly converted to `String`.
       </action>
       <action dev="jodastephen" type="fix" issue="410">
         Fix code generation of light beans for `short`, `byte` and `char` fields.

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanBinFormat.java
@@ -25,7 +25,7 @@ import org.joda.beans.ser.JodaBeanSer;
 public enum JodaBeanBinFormat {
 
     /**
-     * The Standard format, version 1
+     * The Standard format, version 1.
      * <p>
      * The binary format is based on MessagePack v2.0.
      * Each bean is output as a map using the property name.
@@ -55,7 +55,7 @@ public enum JodaBeanBinFormat {
      */
     STANDARD(1),
     /**
-     * The Referencing format, version 2
+     * The Referencing format, version 2.
      * <p>
      * The referencing format is based on the standard format.
      * As a more complex format, it is intended to be consumed only by Joda-Beans
@@ -89,7 +89,7 @@ public enum JodaBeanBinFormat {
      */
     REFERENCING(2),
     /**
-     * Packed format, version 3
+     * Packed format, version 3.
      * <p>
      * This format uses a structure called BeanPack that is similar to MessagePack, but distinctly different.
      * The exact format is not specified and may change over time.

--- a/src/main/java/org/joda/beans/ser/json/JodaBeanJsonNumberFormat.java
+++ b/src/main/java/org/joda/beans/ser/json/JodaBeanJsonNumberFormat.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2001-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.ser.json;
+
+/**
+ * Provides control over the format of unusual JSON numeric values.
+ * 
+ * @since 3.0.0
+ */
+public enum JodaBeanJsonNumberFormat {
+
+    /**
+     * Format using {@code NAN_AS_NULL} when using simple JSON, and {@code STRINGS} when using normal JSON.
+     */
+    COMPATIBLE_V2,
+    /**
+     * Format NaN as {@code null} and Infinity as a string.
+     * <p>
+     * The value will be sent as literal {@code null}, the string {@code "Infinity"} or the string {@code "-Infinity"}.
+     */
+    NAN_AS_NULL,
+    /**
+     * Format NaN and Infinity as a string.
+     * <p>
+     * The value will be sent as the string {@code "NaN"}, {@code "Infinity"} or {@code "-Infinity"}.
+     */
+    STRING,
+    /**
+     * Format NaN and Infinity as a literal, as per 'The JSON5 Data Interchange Format'.
+     * <p>
+     * The value will be sent as the literal {@code NaN}, {@code Infinity} or {@code -Infinity}.
+     */
+    LITERAL;
+
+}

--- a/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
+++ b/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
@@ -156,8 +156,13 @@ public class JodaBeanJsonWriter {
      * @param settings  the settings to use, not null
      */
     public JodaBeanJsonWriter(JodaBeanSer settings) {
+        // COMPATIBLE_V2 value is eliminated here and in the subclass
         JodaBeanUtils.notNull(settings, "settings");
-        this.settings = settings;
+        if (settings.getJsonNumberFormat() == JodaBeanJsonNumberFormat.COMPATIBLE_V2) {
+            this.settings = settings.withJsonNumberFormat(JodaBeanJsonNumberFormat.STRING);
+        } else {
+            this.settings = settings;
+        }
     }
 
     //-----------------------------------------------------------------------
@@ -214,7 +219,7 @@ public class JodaBeanJsonWriter {
     public void write(Bean bean, boolean includeRootType, Appendable output) throws IOException {
         JodaBeanUtils.notNull(bean, "bean");
         JodaBeanUtils.notNull(output, "output");
-        this.output = new JsonOutput(output, settings.getIndent(), settings.getNewLine());
+        this.output = new JsonOutput(output, settings.getJsonNumberFormat(), settings.getIndent(), settings.getNewLine());
         var rootType = includeRootType ? ResolvedType.OBJECT : ResolvedType.of(bean.getClass());
         // root always outputs the bean, not Joda-Convert form
         writeBean(rootType, bean, includeRootType);
@@ -320,7 +325,7 @@ public class JodaBeanJsonWriter {
             output.writeObjectStart();
             output.writeObjectKeyValue(TYPE, "Double");
             output.writeObjectKey(VALUE);
-            output.writeString(Double.toString(val));
+            output.writeDouble(val);
             output.writeObjectEnd();
         }
     }

--- a/src/main/java/org/joda/beans/ser/json/JodaBeanSimpleJsonWriter.java
+++ b/src/main/java/org/joda/beans/ser/json/JodaBeanSimpleJsonWriter.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.joda.beans.Bean;
+import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.ResolvedType;
 import org.joda.beans.ser.JodaBeanSer;
 import org.joda.convert.ToStringConverter;
@@ -52,7 +53,16 @@ public class JodaBeanSimpleJsonWriter extends JodaBeanJsonWriter {
      * @param settings  the settings to use, not null
      */
     public JodaBeanSimpleJsonWriter(JodaBeanSer settings) {
-        super(settings);
+        super(adjustSettings(settings));
+    }
+
+    private static JodaBeanSer adjustSettings(JodaBeanSer settings) {
+        JodaBeanUtils.notNull(settings, "settings");
+        if (settings.getJsonNumberFormat() == JodaBeanJsonNumberFormat.COMPATIBLE_V2) {
+            return settings.withJsonNumberFormat(JodaBeanJsonNumberFormat.NAN_AS_NULL);
+        } else {
+            return settings;
+        }
     }
 
     //-----------------------------------------------------------------------
@@ -109,21 +119,13 @@ public class JodaBeanSimpleJsonWriter extends JodaBeanJsonWriter {
     @Override
     void writeDouble(ResolvedType declaredType, Double val) throws IOException {
         // do not write type
-        if (Double.isNaN(val)) {
-            output.writeNull();
-        } else {
-            output.writeDouble(val);
-        }
+        output.writeDouble(val);
     }
 
     @Override
     void writeFloat(ResolvedType declaredType, Float val) throws IOException {
         // do not write type
-        if (Float.isNaN(val)) {
-            output.writeNull();
-        } else {
-            output.writeFloat(val);
-        }
+        output.writeFloat(val);
     }
 
     //-------------------------------------------------------------------------

--- a/src/main/java/org/joda/beans/ser/json/JsonOutput.java
+++ b/src/main/java/org/joda/beans/ser/json/JsonOutput.java
@@ -46,6 +46,10 @@ final class JsonOutput {
      */
     private final Appendable output;
     /**
+     * The number format.
+     */
+    private final JodaBeanJsonNumberFormat numberFormat;
+    /**
      * The indent amount.
      */
     private final String indent;
@@ -72,18 +76,20 @@ final class JsonOutput {
      * @param output  the output to write to, not null
      */
     JsonOutput(Appendable output) {
-        this(output, "", "");
+        this(output, JodaBeanJsonNumberFormat.STRING, "", "");
     }
 
     /**
      * Creates an instance where the output format can be controlled.
      * 
      * @param output  the output to write to, not null
+     * @param numberFormat  the number format, not null
      * @param indent  the pretty format indent
      * @param newLine  the pretty format new line
      */
-    JsonOutput(Appendable output, String indent, String newLine) {
+    JsonOutput(Appendable output, JodaBeanJsonNumberFormat numberFormat, String indent, String newLine) {
         this.output = output;
+        this.numberFormat = numberFormat;
         this.indent = indent;
         this.newLine = newLine;
     }
@@ -142,8 +148,18 @@ final class JsonOutput {
      * @throws IOException if an error occurs
      */
     void writeFloat(float value) throws IOException {
-        if (Float.isNaN(value) || Float.isInfinite(value)) {
-            output.append('"').append(Float.toString(value)).append('"');
+        if (Float.isNaN(value)) {
+            switch (numberFormat) {
+                case LITERAL -> output.append("NaN");
+                case NAN_AS_NULL -> writeNull();
+                default -> output.append("\"NaN\"");
+            }
+        } else if (Float.isInfinite(value)) {
+            var str = value > 0 ? "Infinity" : "-Infinity";
+            switch (numberFormat) {
+                case LITERAL -> output.append(str);
+                default -> output.append('"').append(str).append('"');
+            }
         } else {
             output.append(Float.toString(value));
         }
@@ -158,8 +174,18 @@ final class JsonOutput {
      * @throws IOException if an error occurs
      */
     void writeDouble(double value) throws IOException {
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
-            output.append('"').append(Double.toString(value)).append('"');
+        if (Double.isNaN(value)) {
+            switch (numberFormat) {
+                case LITERAL -> output.append("NaN");
+                case NAN_AS_NULL -> writeNull();
+                default -> output.append("\"NaN\"");
+            }
+        } else if (Double.isInfinite(value)) {
+            var str = value > 0 ? "Infinity" : "-Infinity";
+            switch (numberFormat) {
+                case LITERAL -> output.append(str);
+                default -> output.append('"').append(str).append('"');
+            }
         } else {
             output.append(Double.toString(value));
         }

--- a/src/test/java/org/joda/beans/ser/json/TestJsonOutput.java
+++ b/src/test/java/org/joda/beans/ser/json/TestJsonOutput.java
@@ -37,7 +37,7 @@ class TestJsonOutput {
     void setUp() {
         buf = new StringBuilder();
         outputCompact = new JsonOutput(buf);
-        outputPretty = new JsonOutput(buf, " ", "\n");
+        outputPretty = new JsonOutput(buf, JodaBeanJsonNumberFormat.STRING, " ", "\n");
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
+++ b/src/test/java/org/joda/beans/ser/json/TestSerializeJson.java
@@ -427,7 +427,31 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_double_PositiveInfinity() {
+    void test_readWrite_double_NaN_null() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.NAN_AS_NULL).jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":null,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NaN_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":NaN,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_PositiveInfinity_string() {
         var bean = new PrimitiveBean();
         bean.setValueDouble(Double.POSITIVE_INFINITY);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
@@ -439,13 +463,48 @@ class TestSerializeJson {
     }
 
     @Test
-    void test_readWrite_double_NegativeInfinity() {
+    void test_readWrite_double_PositiveInfinity_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_double_PositiveInfinity_string() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = """
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":+Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity_string() {
         var bean = new PrimitiveBean();
         bean.setValueDouble(Double.NEGATIVE_INFINITY);
         var json = JodaBeanSer.COMPACT.jsonWriter().write(bean);
         assertThat(json).isEqualTo("""
                 {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
                 "valueDouble":"-Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).jsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"@bean":"org.joda.beans.sample.PrimitiveBean","valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":-Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
         var parsed = JodaBeanSer.COMPACT.jsonReader().read(json);
         BeanAssert.assertBeanEquals(bean, parsed);
     }

--- a/src/test/java/org/joda/beans/ser/json/TestSerializeJsonSimple.java
+++ b/src/test/java/org/joda/beans/ser/json/TestSerializeJsonSimple.java
@@ -55,7 +55,7 @@ class TestSerializeJsonSimple {
     @Test
     void test_writeSimpleJson() throws IOException {
         var bean = SerTestHelper.testSimpleJson();
-        var json = JodaBeanSer.PRETTY.simpleJsonWriter().write(bean);
+        var json = JodaBeanSer.PRETTY.withJsonNumberFormat(JodaBeanJsonNumberFormat.COMPATIBLE_V2).simpleJsonWriter().write(bean);
 //        System.out.println(json);
         assertEqualsSerialization(json, "/org/joda/beans/ser/SimpleJson2.simplejson");
 
@@ -214,6 +214,15 @@ class TestSerializeJsonSimple {
         bean.set("data", Double.NaN);
         var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
         assertThat(json).isEqualTo("""
+                {"data":"NaN"}""");
+    }
+
+    @Test
+    void test_write_doubleObject_NaN_compatible() {
+        var bean = new FlexiBean();
+        bean.set("data", Double.NaN);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.COMPATIBLE_V2).simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
                 {"data":null}""");
     }
 
@@ -242,13 +251,37 @@ class TestSerializeJsonSimple {
         var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
         assertThat(json).isEqualTo("""
                 {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":"NaN","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NaN_compatible() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.COMPATIBLE_V2).simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
                 "valueDouble":null,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
         var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
         BeanAssert.assertBeanEquals(bean, parsed);
     }
 
     @Test
-    void test_readWrite_double_PositiveInfinity() {
+    void test_readWrite_double_NaN_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NaN);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":NaN,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_PositiveInfinity_string() {
         var bean = new PrimitiveBean();
         bean.setValueDouble(Double.POSITIVE_INFINITY);
         var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
@@ -260,13 +293,48 @@ class TestSerializeJsonSimple {
     }
 
     @Test
-    void test_readWrite_double_NegativeInfinity() {
+    void test_readWrite_double_PositiveInfinity_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_read_double_PositiveInfinity_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.POSITIVE_INFINITY);
+        var json = """
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":+Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""";
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity_string() {
         var bean = new PrimitiveBean();
         bean.setValueDouble(Double.NEGATIVE_INFINITY);
         var json = JodaBeanSer.COMPACT.simpleJsonWriter().write(bean);
         assertThat(json).isEqualTo("""
                 {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
                 "valueDouble":"-Infinity","valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
+        var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
+        BeanAssert.assertBeanEquals(bean, parsed);
+    }
+
+    @Test
+    void test_readWrite_double_NegativeInfinity_literal() {
+        var bean = new PrimitiveBean();
+        bean.setValueDouble(Double.NEGATIVE_INFINITY);
+        var json = JodaBeanSer.COMPACT.withJsonNumberFormat(JodaBeanJsonNumberFormat.LITERAL).simpleJsonWriter().write(bean);
+        assertThat(json).isEqualTo("""
+                {"valueLong":0,"valueInt":0,"valueShort":0,"valueByte":0,\
+                "valueDouble":-Infinity,"valueFloat":0.0,"valueChar":"\\u0000","valueBoolean":false}""");
         var parsed = JodaBeanSer.COMPACT.jsonReader().read(json, PrimitiveBean.class);
         BeanAssert.assertBeanEquals(bean, parsed);
     }


### PR DESCRIPTION
* Provide a format switch that can control NaN/Infinity
* Provide a v2 compatibility mode for simple JSON NaN
* Resolves #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `JodaBeanJsonNumberFormat` enum to control JSON number formatting.
	- Added support for handling special numeric values (NaN, Infinity) in JSON serialisation.
	- Enhanced configuration options for numeric value representation.

- **Bug Fixes**
	- Improved handling of numeric values in JSON parsing and writing.
	- Fixed serialisation of special floating-point values across different formats.

- **Documentation**
	- Updated documentation comments for improved clarity.
	- Added explanations for new JSON number formatting options.

- **Compatibility**
	- Ensured backward compatibility with previous JSON serialisation methods.
	- Introduced configuration to support multiple numeric representation strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->