### PR TITLE
Convert ResolvedType to Type

### DIFF
--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinReader.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinReader.java
@@ -87,7 +87,6 @@ final class JodaBeanPackedBinReader extends BeanPack {
     // because this is O(1) whereas switch with pattern match which is O(n)
     private static final ClassValue<BinHandler> LOOKUP = new ClassValue<>() {
 
-        @SuppressWarnings("rawtypes")  // sneaky use of raw type to allow typed value in each method below
         @Override
         protected BinHandler computeValue(Class<?> type) {
             return BaseBinHandlers.INSTANCE.createHandler(type);

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanPackedBinWriter.java
@@ -516,7 +516,7 @@ final class JodaBeanPackedBinWriter {
                 }
             }
             // write content
-            var componentType = declaredType.toComponentTypeOrDefault();
+            var componentType = declaredType.toComponentType();
             writer.output.writeArrayHeader(array.length);
             for (var item : array) {
                 writer.writeObject(componentType, "", item);

--- a/src/main/java/org/joda/beans/ser/bin/JodaBeanStandardBinWriter.java
+++ b/src/main/java/org/joda/beans/ser/bin/JodaBeanStandardBinWriter.java
@@ -269,7 +269,7 @@ final class JodaBeanStandardBinWriter {
         for (var arg : base.getArguments()) {
             var rawType = arg.getRawType();
             if (LOOKUP.get(rawType).isCollection(rawType)) {
-                return base.toRawType();
+                return base.toRaw();
             }
         }
         return base;
@@ -667,7 +667,7 @@ final class JodaBeanStandardBinWriter {
             if (!Optional.class.isAssignableFrom(declaredType.getRawType())) {
                 writeMetaType(writer, "Optional");
             }
-            var valueType = declaredType.getArgumentOrDefault(0).toRawType();
+            var valueType = declaredType.getArgumentOrDefault(0).toRaw();
             writer.writeObject(valueType, "", opt.orElse(null));
         }
 
@@ -681,7 +681,7 @@ final class JodaBeanStandardBinWriter {
 
             return opt
                     .map(value -> (PropertyHandler) () -> {
-                        var valueType = declaredType.getArgumentOrDefault(0).toRawType();
+                        var valueType = declaredType.getArgumentOrDefault(0).toRaw();
                         writer.output.writeString(propertyName);
                         writer.writeObject(valueType, propertyName, value);
                     })
@@ -705,7 +705,7 @@ final class JodaBeanStandardBinWriter {
                 writeMetaType(writer, "GuavaOptional");
             }
             // write content
-            var valueType = declaredType.getArgumentOrDefault(0).toRawType();
+            var valueType = declaredType.getArgumentOrDefault(0).toRaw();
             writer.writeObject(valueType, "", opt.orNull());
         }
 
@@ -719,7 +719,7 @@ final class JodaBeanStandardBinWriter {
 
             return opt
                     .transform(value -> (PropertyHandler) () -> {
-                        var valueType = declaredType.getArgumentOrDefault(0).toRawType();
+                        var valueType = declaredType.getArgumentOrDefault(0).toRaw();
                         writer.output.writeString(propertyName);
                         writer.writeObject(valueType, propertyName, value);
                     })

--- a/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
+++ b/src/main/java/org/joda/beans/ser/json/JodaBeanJsonWriter.java
@@ -273,7 +273,7 @@ public class JodaBeanJsonWriter {
             if (settings.isSerialized(metaProperty)) {
                 var value = metaProperty.get(bean);
                 if (value != null) {
-                    var resolvedType = ResolvedType.from(metaProperty.propertyGenericType(), bean.getClass());
+                    var resolvedType = metaProperty.propertyResolvedType(bean.getClass());
                     var handler = LOOKUP.get(value.getClass());
                     handler.handleProperty(this, resolvedType, metaProperty.name(), value);
                 }
@@ -478,7 +478,7 @@ public class JodaBeanJsonWriter {
         for (var arg : base.getArguments()) {
             var rawType = arg.getRawType();
             if (LOOKUP.get(rawType).isCollection()) {
-                return base.toRawType();
+                return base.toRaw();
             }
         }
         return base;
@@ -895,7 +895,7 @@ public class JodaBeanJsonWriter {
                 String propertyName,
                 Optional<?> opt) throws IOException {
 
-            var valueType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(0).toRaw();
             writer.writeObject(valueType, "", opt.orElse(null));
         }
 
@@ -909,7 +909,7 @@ public class JodaBeanJsonWriter {
 
             var value = opt.orElse(null);
             if (value != null) {
-                var valueType = declaredType.getArgumentOrDefault(0);
+                var valueType = declaredType.getArgumentOrDefault(0).toRaw();
                 writer.output.writeObjectKey(propertyName);
                 writer.writeObject(valueType, propertyName, value);
             }
@@ -928,7 +928,7 @@ public class JodaBeanJsonWriter {
                 String propertyName,
                 com.google.common.base.Optional<?> opt) throws IOException {
 
-            var valueType = declaredType.getArgumentOrDefault(0);
+            var valueType = declaredType.getArgumentOrDefault(0).toRaw();
             writer.writeObject(valueType, "", opt.orNull());
         }
 
@@ -942,7 +942,7 @@ public class JodaBeanJsonWriter {
 
             var value = opt.orNull();
             if (value != null) {
-                var valueType = declaredType.getArgumentOrDefault(0);
+                var valueType = declaredType.getArgumentOrDefault(0).toRaw();
                 writer.output.writeObjectKey(propertyName);
                 writer.writeObject(valueType, propertyName, value);
             }


### PR DESCRIPTION
* Allow a `ResolvedType` to be converted to a `Type`
* Rename methods and add Javadoc for clarity
* Fix uses of resolved type in Binary/JSON serialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced type resolution capabilities in the Joda Beans library.
  - Improved handling of generic types and arrays.
  - Added support for serializable type resolution.
  - Added conversion from resolved types back to Java reflection types.

- **Improvements**
  - Refined parsing logic with recursion depth limits to prevent infinite loops.
  - Updated method signatures to support flexible handling including raw type allowances.
  - Standardised raw type handling for collections and optional types during JSON and binary serialization.
  - Adjusted array component type resolution during serialization for improved accuracy.

- **Testing**
  - Expanded test coverage for complex, dynamic, and array type scenarios.
  - Added new tests for conversion between resolved types and Java types.

These updates improve the library’s type handling and provide more robust, flexible type resolution mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->